### PR TITLE
Check cache freshness

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -280,9 +280,15 @@ class Server
     public function makeImage()
     {
         $request = $this->resolveRequestObject(func_get_args());
+        $cachePath = $this->getCachePath($request);
+        $sourcePath = $this->getSourcePath($request);
 
         if ($this->cacheFileExists($request) === true) {
-            return $request;
+            if ($this->cache->getTimestamp($cachePath) >= $this->source->getTimestamp($sourcePath)) {
+                return $request;
+            } else {
+                $this->cache->delete($cachePath);
+            }
         }
 
         if ($this->sourceFileExists($request) === false) {


### PR DESCRIPTION
This validates the timestamp of the cache and source. If the cache isn't fresh anymore, the cache file is deleted.
Not sure if this should be optional or anything, because it will impact performance (every requests needs to make an API call).

Usecase is that the source image could be changed, but this will not be reflected in the Glide image.

For performance, a caching adapter for Flysystem could be suggested, which caches all calls (except for the content) so the impact wouldn't be very much. (http://flysystem.thephpleague.com/caching/)