### PR TITLE
Decode URL entities in path

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -123,7 +123,7 @@ class Server
             $path = $this->sourcePathPrefix.'/'.$path;
         }
 
-        return urldecode($path);
+        return rawurldecode($path);
     }
 
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -123,7 +123,7 @@ class Server
             $path = $this->sourcePathPrefix.'/'.$path;
         }
 
-        return $path;
+        return urldecode($path);
     }
 
     /**

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -78,6 +78,12 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->server->getSourcePath('');
     }
 
+    public function testGetSourcePathWithEncodedEntities()
+    {
+        $this->assertEquals('an image.jpg', $this->server->getSourcePath('an%20image.jpg'));
+        $this->assertEquals('an image.jpg', $this->server->getSourcePath(RequestFactory::create('an%20image.jpg')));
+    }
+
     public function testSourceFileExists()
     {
         $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {


### PR DESCRIPTION
Simply wrapping the `$path` returned in `getSourcePath()` with `urldecode()` appears to fix #32.