### PR TITLE
Add graceful handling of cache write failure due to already existent cache file caused by race condition.

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -3,6 +3,7 @@
 namespace League\Glide;
 
 use InvalidArgumentException;
+use League\Flysystem\FileExistsException;
 use League\Flysystem\FilesystemInterface;
 use League\Glide\Api\ApiInterface;
 use League\Glide\Filesystem\FilesystemException;
@@ -299,10 +300,15 @@ class Server
             );
         }
 
-        $write = $this->cache->write(
-            $this->getCachePath($request),
-            $this->api->run($request, $source)
-        );
+        try {
+            $write = $this->cache->write(
+                $this->getCachePath($request),
+                $this->api->run($request, $source)
+            );
+        } catch (FileExistsException $exception) {
+            // Cache file failed to write. Fail silently.
+            return $request;
+        }
 
         if ($write === false) {
             throw new FilesystemException(

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -279,6 +279,25 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->server->makeImage('image.jpg');
     }
 
+    public function testMakeImageWithExistingCacheFile()
+    {
+        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
+            $mock->shouldReceive('has')->andReturn(true)->once();
+            $mock->shouldReceive('read')->andReturn('content')->once();
+        }));
+
+        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
+            $mock->shouldReceive('has')->andReturn(false)->once();
+            $mock->shouldReceive('write')->andThrow(new \League\Flysystem\FileExistsException('75094881e9fd2b93063d6a5cb083091c'));
+        }));
+
+        $this->server->setApi(Mockery::mock('League\Glide\Api\ApiInterface', function ($mock) {
+            $mock->shouldReceive('run')->andReturn('content')->once();
+        }));
+
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Request', $this->server->makeImage('image.jpg'));
+    }
+
     public function testMakeImageFromSource()
     {
         $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {


### PR DESCRIPTION
These changes address the concurrent cache write issue revealed by https://github.com/thephpleague/glide/issues/38.