### PR TITLE
A bunch of stuff for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,13 @@ php:
   - 7.0
   - hhvm
 
+env:
+  - COMPOSER_OPTS=""
+  - COMPOSER_OPTS="--prefer-lowest"
+
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --no-interaction --prefer-source --dev
+  - travis_retry composer update $COMPOSER_OPTS
 
 script:
   - php vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ php:
   - 7.0
   - hhvm
 
+sudo: false
+
 env:
   - COMPOSER_OPTS=""
   - COMPOSER_OPTS="--prefer-lowest"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "intervention/image": "~2.0",
+        "intervention/image": "~2.1",
         "league/flysystem": "~1.0",
         "symfony/http-foundation": "~2.3",
         "symfony/http-kernel": "~2.3"

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     },
     "require-dev": {
         "mockery/mockery": "~0.9",
+        "phpunit/php-token-stream": ">=1.3.0",
         "phpunit/phpunit": "~4.4"
     },
     "autoload": {


### PR DESCRIPTION
* Use `composer update` to test against the highest dependencies
* Also test against the lowest supported dependencies
* Added testing on the upcoming php release (7.0)
* Use [container-based](http://docs.travis-ci.com/user/workers/container-based-infrastructure/) travis builds 

Doing this uncovered an [issue](https://travis-ci.org/duncan3dc/glide/builds/52405993) in the dependencies. This looks like a problem in `intervention/image`, where they are misstating their lowest supported dependencies. Bumping glide's supported version to `~2.1` fixes that but I'm not sure whether you'd rather pursue a fix with intervention instead.