### PR TITLE
Image is not resized

### DIFF
--- a/src/Api/Manipulator/Size.php
+++ b/src/Api/Manipulator/Size.php
@@ -56,7 +56,7 @@ class Size implements ManipulatorInterface
         list($width, $height) = $this->resolveMissingDimensions($image, $width, $height);
         list($width, $height) = $this->limitImageSize($width, $height);
 
-        if (round($width) !== round($image->width()) and
+        if (round($width) !== round($image->width()) or
             round($height) !== round($image->height())) {
             $image = $this->runResize($image, $fit, round($width), round($height), $crop);
         }

--- a/tests/Api/Manipulator/SizeTest.php
+++ b/tests/Api/Manipulator/SizeTest.php
@@ -43,7 +43,7 @@ class SizeTest extends \PHPUnit_Framework_TestCase
     {
         $image = Mockery::mock('Intervention\Image\Image', function ($mock) {
             $mock->shouldReceive('width')->andReturn('200')->twice();
-            $mock->shouldReceive('height')->andReturn('200')->twice();
+            $mock->shouldReceive('height')->andReturn('200')->once();
             $mock->shouldReceive('resize')->with('100', '100', $this->callback)->andReturn($mock)->once();
         });
 


### PR DESCRIPTION
When one of the dimensions requested is the same as the original the image is not resized.