### PR TITLE
Add the ability to disable caching by passing false as the cache parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 composer.lock
 vendor
+.DS_STORE

--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -79,6 +79,10 @@ class ServerFactory
             $cache = $this->config['cache'];
         }
 
+        if ($cache === false) {
+            return null;
+        }
+
         if (is_string($cache)) {
             return new Filesystem(new Local($cache));
         }


### PR DESCRIPTION
WIP. As per Jonathan's request, this potential fix for Glide's current inability to disable caching is being submitted as a pull request without unit test updates for the sake of implementation review.

These modifications enable the passing of boolean false as the value for the ‘cache’ parameter to the server factory. Doing so bypasses the cache writing process and serves the image from source.