### PR TITLE
Remove .DS_STORE from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 build
 composer.lock
 vendor
-.DS_STORE


### PR DESCRIPTION
This should never have been added. It belongs in your system .gitignore file.