### PR TITLE
Add fit=fill feature for resize

### DIFF
--- a/src/Manipulators/Size.php
+++ b/src/Manipulators/Size.php
@@ -104,7 +104,7 @@ class Size extends BaseManipulator
      */
     public function getFit()
     {
-        if (in_array($this->fit, ['contain', 'max', 'stretch'], true)) {
+        if (in_array($this->fit, ['contain', 'fill', 'max', 'stretch'], true)) {
             return $this->fit;
         }
 
@@ -254,6 +254,10 @@ class Size extends BaseManipulator
             return $this->runContainResize($image, $width, $height);
         }
 
+        if ($fit === 'fill') {
+            return $this->runFillResize($image, $width, $height);
+        }
+
         if ($fit === 'max') {
             return $this->runMaxResize($image, $width, $height);
         }
@@ -296,6 +300,19 @@ class Size extends BaseManipulator
             $constraint->aspectRatio();
             $constraint->upsize();
         });
+    }
+
+    /**
+     * Perform fill resize image manipulation.
+     * @param  Image  $image  The source image.
+     * @param  string $width  The width.
+     * @param  string $height The height.
+     * @return Image  The manipulated image.
+     */
+    public function runFillResize($image, $width, $height)
+    {
+        $image = $this->runMaxResize($image, $width, $height);
+        return $image->resizeCanvas($width, $height, 'center');
     }
 
     /**

--- a/tests/Manipulators/SizeTest.php
+++ b/tests/Manipulators/SizeTest.php
@@ -73,6 +73,7 @@ class SizeTest extends \PHPUnit_Framework_TestCase
     public function testGetFit()
     {
         $this->assertSame('contain', $this->manipulator->setParams(['fit' => 'contain'])->getFit());
+        $this->assertSame('fill', $this->manipulator->setParams(['fit' => 'fill'])->getFit());
         $this->assertSame('max', $this->manipulator->setParams(['fit' => 'max'])->getFit());
         $this->assertSame('stretch', $this->manipulator->setParams(['fit' => 'stretch'])->getFit());
         $this->assertSame('crop', $this->manipulator->setParams(['fit' => 'crop'])->getFit());
@@ -118,14 +119,20 @@ class SizeTest extends \PHPUnit_Framework_TestCase
     public function testRunResize()
     {
         $image = Mockery::mock('Intervention\Image\Image', function ($mock) {
-            $mock->shouldReceive('resize')->with('100', '100', $this->callback)->andReturn($mock)->twice();
+            $mock->shouldReceive('resize')->with('100', '100', $this->callback)->andReturn($mock)->times(3);
             $mock->shouldReceive('resize')->with('100', '100')->andReturn($mock)->once();
+            $mock->shouldReceive('resizeCanvas')->with('100', '100', 'center')->andReturn($mock)->once();
             $mock->shouldReceive('fit')->with('100', '100', $this->callback, 'center')->andReturn($mock)->once();
         });
 
         $this->assertInstanceOf(
             'Intervention\Image\Image',
             $this->manipulator->runResize($image, 'contain', '100', '100')
+        );
+
+        $this->assertInstanceOf(
+            'Intervention\Image\Image',
+            $this->manipulator->runResize($image, 'fill', '100', '100')
         );
 
         $this->assertInstanceOf(
@@ -153,6 +160,19 @@ class SizeTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(
             'Intervention\Image\Image',
             $this->manipulator->runContainResize($image, '100', '100')
+        );
+    }
+
+    public function testRunFillResize()
+    {
+        $image = Mockery::mock('Intervention\Image\Image', function($mock) {
+            $mock->shouldReceive('resize')->with('100', '100', $this->callback)->andReturn($mock)->once();
+            $mock->shouldReceive('resizeCanvas')->with('100', '100', 'center')->andReturn($mock)->once();
+        });
+
+        $this->assertInstanceOf(
+            'Intervention\Image\Image',
+            $this->manipulator->runFillResize($image, '100', '100')
         );
     }
 


### PR DESCRIPTION
When resizing an image which is smaller than the dimensions you want to
resize it to in one or both directions, the fit=fill option allows you
to specify a fill color (when combined with the Background manipulator)
to fill the extra canvas space.

This is accomplished using a query like `?w=300&fit=fill&bg=000` to resize
the image to 300 pixels wide while filling any new canvas space with
black.