### PR TITLE
Added a ColorSpace Manipulator

### DIFF
--- a/src/Manipulators/ColorSpace.php
+++ b/src/Manipulators/ColorSpace.php
@@ -29,7 +29,7 @@ class ColorSpace extends BaseManipulator
 
         $this->colorSpaces = [
             'rgb' => \Imagick::COLORSPACE_RGB,
-            'srgb' => \Imagick::COLORSPACE_RGB,
+            'srgb' => \Imagick::COLORSPACE_SRGB,
             'cmyk' => \Imagick::COLORSPACE_CMYK
         ];
 

--- a/src/Manipulators/ColorSpace.php
+++ b/src/Manipulators/ColorSpace.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace League\Glide\Manipulators;
+
+use Intervention\Image\Image;
+
+/**
+ * @property string $cs
+ */
+class ColorSpace extends BaseManipulator
+{
+    /**
+     * Possible color spaces
+     *
+     * @var array
+     */
+    private $colorSpaces = [];
+
+    /**
+     * Perform color space image manipulation.
+     * @param  Image $image The source image.
+     * @return Image The manipulated image.
+     */
+    public function run(Image $image)
+    {
+        if ($image->getDriver()->getDriverName() !== 'Imagick') {
+            return $image;
+        }
+
+        $this->colorSpaces = [
+            'rgb' => \Imagick::COLORSPACE_RGB,
+            'srgb' => \Imagick::COLORSPACE_RGB,
+            'cmyk' => \Imagick::COLORSPACE_CMYK
+        ];
+
+        $colorSpace = $this->getColorSpace();
+
+        if ($colorSpace !== null) {
+            $image->getCore()->transformimagecolorspace($colorSpace);
+        }
+
+        return $image;
+    }
+
+    /**
+     * Resolve color space value.
+     * @return integer The resolved color space value.
+     */
+    public function getColorSpace()
+    {
+        if (!in_array($this->cs, array_keys($this->colorSpaces), true)) {
+            return;
+        }
+
+        return $this->colorSpaces[$this->cs];
+    }
+}

--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -11,6 +11,7 @@ use League\Glide\Manipulators\Background;
 use League\Glide\Manipulators\Blur;
 use League\Glide\Manipulators\Border;
 use League\Glide\Manipulators\Brightness;
+use League\Glide\Manipulators\ColorSpace;
 use League\Glide\Manipulators\Contrast;
 use League\Glide\Manipulators\Crop;
 use League\Glide\Manipulators\Encode;
@@ -188,6 +189,7 @@ class ServerFactory
     public function getManipulators()
     {
         return [
+            new ColorSpace(),
             new Orientation(),
             new Crop(),
             new Size($this->getMaxImageSize()),


### PR DESCRIPTION
I needed the ability to change the color space when working with the Imagick driver. Prior to being able to change the color space my Glide generated images were being generated with incorrect colors. With this update a user can use the "cs" option to the specify one of the defined colorspaces (rgb, srgb, cmyk). I wasn't sure if this was possible with the GD driver so my implementation only works with Imagick. Intervention also does not implement any commands to handle this so I had to use the Imagick driver directly.