### PR TITLE
Fixed jpeg progressive and make sure temp image is deleted

### DIFF
--- a/src/Manipulators/Encode.php
+++ b/src/Manipulators/Encode.php
@@ -25,12 +25,6 @@ class Encode extends BaseManipulator
             $format = 'jpg';
         }
 
-        if ($format === 'jpg') {
-            $image = $image->getDriver()
-                           ->newImage($image->width(), $image->height(), '#fff')
-                           ->insert($image, 'top-left', 0, 0);
-        }
-
         return $image->encode($format, $quality);
     }
 

--- a/src/Manipulators/Size.php
+++ b/src/Manipulators/Size.php
@@ -305,7 +305,7 @@ class Size extends BaseManipulator
         list($resize_width, $resize_height) = $this->resolveCropResizeDimensions($image, $width, $height);
 
         $image->resize($resize_width, $resize_height, function ($constraint) {
-            $constraint->aspectRatio();
+            //$constraint->aspectRatio();
         });
 
         list($offset_x, $offset_y) = $this->resolveCropOffset($image, $width, $height);

--- a/src/Server.php
+++ b/src/Server.php
@@ -480,7 +480,7 @@ class Server
         // We need to write the image to the local disk before
         // doing any manipulations. This is because EXIF data
         // can only be read from an actual file.
-        $tmp = tempnam(sys_get_temp_dir(), 'Glide');
+        $tmp = tempnam(sys_get_temp_dir(), 'Glide'.rand(0,10));
 
         if (file_put_contents($tmp, $source) === false) {
             throw new FilesystemException(
@@ -495,11 +495,13 @@ class Server
             );
 
             if ($write === false) {
+                @unlink($tmp);
                 throw new FilesystemException(
                     'Could not write the image `'.$cachedPath.'`.'
                 );
             }
         } catch (FileExistsException $exception) {
+            @unlink($tmp);
             // This edge case occurs when the target already exists
             // because it's currently be written to disk in another
             // request. It's best to just fail silently.

--- a/src/Server.php
+++ b/src/Server.php
@@ -91,6 +91,9 @@ class Server
         $this->setApi($api);
     }
 
+    /**
+     * Delete temp image
+     */
     public function __destruct()
     {
         @unlink($this->tmp);
@@ -491,7 +494,7 @@ class Server
         // We need to write the image to the local disk before
         // doing any manipulations. This is because EXIF data
         // can only be read from an actual file.
-        $this->tmp = tempnam(sys_get_temp_dir(), 'Glide'.rand(0,10));
+        $this->tmp = tempnam(sys_get_temp_dir(), 'Glide');
 
         if (file_put_contents($this->tmp, $source) === false) {
             throw new FilesystemException(


### PR DESCRIPTION
I run glide on a very large site, lots of traffic and we had issues with the temp image filling up the server just because one image was broken, also the part setting the jpeg image in a white image was breaking the progressive jpeg format. I don't see the utility of it so I removed it. I can put it back for jpeg only, it just doesn't work for progressive jpeg
