### PR TITLE
Make sure stream is seekable before using `rewind()`

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -439,7 +439,9 @@ class Server
 
         $stream = $this->cache->readStream($path);
 
-        rewind($stream);
+        if (ftell($stream) !== 0) {
+            rewind($stream);
+        }
         fpassthru($stream);
         fclose($stream);
     }


### PR DESCRIPTION
This commit fixes possible `rewind(): stream does not support seeking` errors.