### PR TITLE
Add support for caching with file extensions

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -43,6 +43,12 @@ class Server
     protected $groupCacheInFolders = true;
 
     /**
+     * Whether to cache with file extensions.
+     * @var bool
+     */
+    protected $cacheWithFileExtensions = false;
+
+    /**
      * Image manipulation API.
      * @var ApiInterface
      */
@@ -229,6 +235,24 @@ class Server
     }
 
     /**
+     * Set the cache with file extensions setting.
+     * @param bool $groupCacheInFolders Whether to cache with file extensions.
+     */
+    public function setCacheWithFileExtensions($cacheWithFileExtensions)
+    {
+        $this->cacheWithFileExtensions = $cacheWithFileExtensions;
+    }
+
+    /**
+     * Get the cache with file extensions setting.
+     * @return bool Whether to cache with file extensions.
+     */
+    public function getCacheWithFileExtensions()
+    {
+        return $this->cacheWithFileExtensions;
+    }
+
+    /**
      * Get cache path.
      * @param  string $path   Image path.
      * @param  array  $params Image manipulation params.
@@ -248,13 +272,17 @@ class Server
 
         $md5 = md5($sourcePath.'?'.http_build_query($params));
 
-        $path = $this->groupCacheInFolders ? $sourcePath.'/'.$md5 : $md5;
+        $cachedPath = $this->groupCacheInFolders ? $sourcePath.'/'.$md5 : $md5;
 
         if ($this->cachePathPrefix) {
-            $path = $this->cachePathPrefix.'/'.$path;
+            $cachedPath = $this->cachePathPrefix.'/'.$cachedPath;
+        }
+        
+        if ($this->cacheWithFileExtensions) {
+            $cachedPath .= '.'.pathinfo($path)['extension'];
         }
 
-        return $path;
+        return $cachedPath;
     }
 
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -279,8 +279,7 @@ class Server
         }
         
         if ($this->cacheWithFileExtensions) {
-            $ext = isset($params['fm']) ? $params['fm'] : pathinfo($path)['extension'];
-            $cachedPath .= '.'.$ext;
+            $cachedPath .= '.'.(isset($params['fm']) ? $params['fm'] : pathinfo($path)['extension']);
         }
 
         return $cachedPath;

--- a/src/Server.php
+++ b/src/Server.php
@@ -279,7 +279,8 @@ class Server
         }
         
         if ($this->cacheWithFileExtensions) {
-            $cachedPath .= '.'.pathinfo($path)['extension'];
+            $ext = isset($params['fm']) ? $params['fm'] : pathinfo($path)['extension'];
+            $cachedPath .= '.'.$ext;
         }
 
         return $cachedPath;

--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -56,6 +56,7 @@ class ServerFactory
         $server->setSourcePathPrefix($this->getSourcePathPrefix());
         $server->setCachePathPrefix($this->getCachePathPrefix());
         $server->setGroupCacheInFolders($this->getGroupCacheInFolders());
+        $server->setCacheWithFileExtensions($this->getCacheWithFileExtensions());
         $server->setDefaults($this->getDefaults());
         $server->setPresets($this->getPresets());
         $server->setBaseUrl($this->getBaseUrl());
@@ -135,6 +136,19 @@ class ServerFactory
         }
 
         return true;
+    }
+
+    /**
+     * Get the cache with file extensions setting.
+     * @return bool Whether to cache with file extensions.
+     */
+    public function getCacheWithFileExtensions()
+    {
+        if (isset($this->config['cache_with_file_extensions'])) {
+            return $this->config['cache_with_file_extensions'];
+        }
+
+        return false;
     }
 
     /**

--- a/tests/ServerFactoryTest.php
+++ b/tests/ServerFactoryTest.php
@@ -105,6 +105,19 @@ class ServerFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($server->getGroupCacheInFolders());
     }
 
+    public function testGetCacheWithFileExtensions()
+    {
+        $server = new ServerFactory();
+
+        $this->assertFalse($server->getCacheWithFileExtensions());
+
+        $server = new ServerFactory([
+            'cache_with_file_extensions' => true,
+        ]);
+
+        $this->assertTrue($server->getCacheWithFileExtensions());
+    }
+
     public function testGetWatermarks()
     {
         $server = new ServerFactory([

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -194,6 +194,30 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->server->setCacheWithFileExtensions(true);
         $this->assertEquals('image.jpg/75094881e9fd2b93063d6a5cb083091c.jpg', $this->server->getCachePath('image.jpg', []));
     }
+    
+    public function testGetCachePathWithExtensionAndFmParam()
+    {
+        $this->server->setCacheWithFileExtensions(true);
+        $this->assertEquals('image.jpg/eb6091e07fb06219634a3c82afb88239.gif', $this->server->getCachePath('image.jpg', ['fm' => 'gif']));
+    }
+    
+    public function testGetCachePathWithExtensionAndFmFromDefaults()
+    {
+        $this->server->setCacheWithFileExtensions(true);
+        $this->server->setDefaults(['fm' => 'gif']);
+        $this->assertEquals('image.jpg/eb6091e07fb06219634a3c82afb88239.gif', $this->server->getCachePath('image.jpg', []));
+    }
+    
+    public function testGetCachePathWithExtensionAndFmFromPreset()
+    {
+        $this->server->setCacheWithFileExtensions(true);
+        
+        $this->server->setPresets(['gif' => [
+            'fm' => 'gif'
+        ]]);
+        
+        $this->assertEquals('image.jpg/eb6091e07fb06219634a3c82afb88239.gif', $this->server->getCachePath('image.jpg', ['p' => 'gif']));
+    }
 
     public function testCacheFileExists()
     {

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -147,6 +147,18 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->server->getGroupCacheInFolders());
     }
 
+    public function testSetCacheWithFileExtensions()
+    {
+        $this->server->setCacheWithFileExtensions(true);
+
+        $this->assertTrue($this->server->getCacheWithFileExtensions());
+    }
+
+    public function testGetCacheWithFileExtensions()
+    {
+        $this->assertFalse($this->server->getCacheWithFileExtensions());
+    }
+
     public function testGetCachePath()
     {
         $this->assertEquals(
@@ -175,6 +187,12 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     {
         $this->server->setSourcePathPrefix('img/');
         $this->assertEquals('image.jpg/75094881e9fd2b93063d6a5cb083091c', $this->server->getCachePath('image.jpg', []));
+    }
+    
+    public function testGetCachePathWithExtension()
+    {
+        $this->server->setCacheWithFileExtensions(true);
+        $this->assertEquals('image.jpg/75094881e9fd2b93063d6a5cb083091c.jpg', $this->server->getCachePath('image.jpg'), []);
     }
 
     public function testCacheFileExists()

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -192,7 +192,7 @@ class ServerTest extends \PHPUnit_Framework_TestCase
     public function testGetCachePathWithExtension()
     {
         $this->server->setCacheWithFileExtensions(true);
-        $this->assertEquals('image.jpg/75094881e9fd2b93063d6a5cb083091c.jpg', $this->server->getCachePath('image.jpg'), []);
+        $this->assertEquals('image.jpg/75094881e9fd2b93063d6a5cb083091c.jpg', $this->server->getCachePath('image.jpg', []));
     }
 
     public function testCacheFileExists()


### PR DESCRIPTION
Hey there.

I'd like to be able to add file extensions to the cached images so they can be served directly.

In our app (Statamic, in this case), we'll have an option to pre-generate the images and use this approach. Obviously we'd lose the dynamic URL based nature of Glide, but this would be a switch people could flick to increase performance.

On heavier sites, loading an image directly is considerably faster than bootstrapping the app.