### PR TITLE
Documentation: Add Request object to LaravelResponseFactory

### DIFF
--- a/docs/1.0/config/integrations/laravel.md
+++ b/docs/1.0/config/integrations/laravel.md
@@ -24,6 +24,6 @@ use League\Glide\ServerFactory;
 use League\Glide\Responses\LaravelResponseFactory;
 
 $server = ServerFactory::create([
-    'response' => new LaravelResponseFactory()
+    'response' => new LaravelResponseFactory(app('request'))
 ]);
 ~~~


### PR DESCRIPTION
The `SymfonyResponseFactory` can be constructed with an instance of the `Symfony\Component\HttpFoundation\Request`.
This will set the `last-modified` header based on the timestamp of the cached image.

Perhaps this should be added to the Symfony integration page as well, but I'm not sure how to pass in the Request object.