### PR TITLE
Fix source being trimmed when it begins with the baseUrl

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -136,9 +136,11 @@ class Server
     public function getSourcePath($path)
     {
         $path = trim($path, '/');
+        
+        $baseUrl = $this->baseUrl.'/';
 
-        if (substr($path, 0, strlen($this->baseUrl)) === $this->baseUrl) {
-            $path = trim(substr($path, strlen($this->baseUrl)), '/');
+        if (substr($path, 0, strlen($baseUrl)) === $baseUrl) {
+            $path = trim(substr($path, strlen($baseUrl)), '/');
         }
 
         if ($path === '') {

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -78,6 +78,16 @@ class ServerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('img/image.jpg', $this->server->getSourcePath('image.jpg'));
     }
 
+    public function testGetsSourcePathWithBaseUrl()
+    {
+        $this->server->setBaseUrl('img/');
+        $this->assertEquals('image.jpg', $this->server->getSourcePath('image.jpg'));
+        
+        // Test for a bug where if the path starts with the same substring as the base url, the source
+        // path would trim the base url off the filename. eg, the following would've returned 'ur.jpg'
+        $this->assertEquals('imgur.jpg', $this->server->getSourcePath('imgur.jpg'));
+    }
+
     public function testGetSourcePathWithMissingPath()
     {
         $this->setExpectedException(


### PR DESCRIPTION
I ran into a bug where if a path started with the baseUrl, it would get trimmed off incorrectly.

For example: if your `baseUrl` is `img`, and you do `$server->getSourcePath('imgur.jpg')` or `'img-0001.jpg` or something, it would return `ur.jpg` and `-0001` respectively.

I believe this PR fixes it by making sure there's a slash in the substring.