### PR TITLE
Fix typo in documentation.

### DIFF
--- a/docs/1.0/config/integrations/zend.md
+++ b/docs/1.0/config/integrations/zend.md
@@ -10,7 +10,7 @@ If your application uses the [Zend Diactoros](https://github.com/zendframework/z
 ## Installation
 
 ~~~ bash
-composer require league/zend
+composer require league/glide-zend
 ~~~
 
 ## Configuration


### PR DESCRIPTION
Documentation for the Zend Diactoros Response Factory references an incorrect composer package name.