### PR TITLE
Adds Support For WebP images

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "intervention/image": "^2.1",
+        "intervention/image": "^2.4",
         "league/flysystem": "^1.0",
         "php": "^5.4 | ^7.0",
         "psr/http-message": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d6ed74d992f9e0130fe60f320e27e369",
-    "content-hash": "574ea4e476c8eb2f9a7e24298b4bbc4e",
+    "content-hash": "2f78ba825509d18be91a4472854b71f7",
     "packages": [
         {
             "name": "guzzlehttp/psr7",
@@ -63,20 +62,20 @@
                 "stream",
                 "uri"
             ],
-            "time": "2016-06-24 23:00:38"
+            "time": "2016-06-24T23:00:38+00:00"
         },
         {
             "name": "intervention/image",
-            "version": "2.3.7",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Intervention/image.git",
-                "reference": "22088b04728a039bd1fc32f7e79a89a118b78698"
+                "reference": "3603dbcc9a17d307533473246a6c58c31cf17919"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Intervention/image/zipball/22088b04728a039bd1fc32f7e79a89a118b78698",
-                "reference": "22088b04728a039bd1fc32f7e79a89a118b78698",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/3603dbcc9a17d307533473246a6c58c31cf17919",
+                "reference": "3603dbcc9a17d307533473246a6c58c31cf17919",
                 "shasum": ""
             },
             "require": {
@@ -86,7 +85,7 @@
             },
             "require-dev": {
                 "mockery/mockery": "~0.9.2",
-                "phpunit/phpunit": "3.*"
+                "phpunit/phpunit": "^4.8 || ^5.7"
             },
             "suggest": {
                 "ext-gd": "to use GD library based image processing.",
@@ -97,6 +96,14 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "2.3-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Intervention\\Image\\ImageServiceProvider"
+                    ],
+                    "aliases": {
+                        "Image": "Intervention\\Image\\Facades\\Image"
+                    }
                 }
             },
             "autoload": {
@@ -111,8 +118,8 @@
             "authors": [
                 {
                     "name": "Oliver Vogel",
-                    "email": "oliver@olivervogel.net",
-                    "homepage": "http://olivervogel.net/"
+                    "email": "oliver@olivervogel.com",
+                    "homepage": "http://olivervogel.com/"
                 }
             ],
             "description": "Image handling and manipulation library with support for Laravel integration",
@@ -125,7 +132,7 @@
                 "thumbnail",
                 "watermark"
             ],
-            "time": "2016-04-26 14:08:40"
+            "time": "2017-09-21T16:29:17+00:00"
         },
         {
             "name": "league/flysystem",
@@ -208,7 +215,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2016-08-10 08:55:11"
+            "time": "2016-08-10T08:55:11+00:00"
         },
         {
             "name": "psr/http-message",
@@ -258,7 +265,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         }
     ],
     "packages-dev": [
@@ -314,7 +321,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -359,19 +366,19 @@
             "keywords": [
                 "test"
             ],
-            "time": "2015-05-11 14:41:42"
+            "time": "2015-05-11T14:41:42+00:00"
         },
         {
             "name": "mockery/mockery",
             "version": "0.9.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/padraic/mockery.git",
+                "url": "https://github.com/mockery/mockery.git",
                 "reference": "4db079511a283e5aba1b3c2fb19037c645e70fc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/padraic/mockery/zipball/4db079511a283e5aba1b3c2fb19037c645e70fc2",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/4db079511a283e5aba1b3c2fb19037c645e70fc2",
                 "reference": "4db079511a283e5aba1b3c2fb19037c645e70fc2",
                 "shasum": ""
             },
@@ -424,7 +431,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2016-05-22 21:52:33"
+            "time": "2016-05-22T21:52:33+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -478,7 +485,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -523,7 +530,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-06-10 09:48:41"
+            "time": "2016-06-10T09:48:41+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -570,7 +577,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-06-10 07:14:17"
+            "time": "2016-06-10T07:14:17+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -632,7 +639,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-06-07 08:13:47"
+            "time": "2016-06-07T08:13:47+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -694,7 +701,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -741,7 +748,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2015-06-21T13:08:43+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -782,7 +789,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -826,7 +833,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -875,7 +882,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2015-09-15T10:49:45+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -947,7 +954,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-07-21 06:48:14"
+            "time": "2016-07-21T06:48:14+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1003,7 +1010,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -1067,7 +1074,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2015-07-26T15:48:44+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1119,7 +1126,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1169,7 +1176,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1236,7 +1243,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1287,7 +1294,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1340,7 +1347,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2015-11-11T19:50:13+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1375,7 +1382,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -1424,7 +1431,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-17 14:02:08"
+            "time": "2016-07-17T14:02:08+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1474,7 +1481,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-08-09 15:02:57"
+            "time": "2016-08-09T15:02:57+00:00"
         }
     ],
     "aliases": [],

--- a/src/Manipulators/Encode.php
+++ b/src/Manipulators/Encode.php
@@ -46,6 +46,7 @@ class Encode extends BaseManipulator
             'jpg' => 'image/jpeg',
             'pjpg' => 'image/jpeg',
             'png' => 'image/png',
+	        'webp' => 'image/webp'
         ];
 
         if (array_key_exists($this->fm, $allowed)) {

--- a/src/Manipulators/Encode.php
+++ b/src/Manipulators/Encode.php
@@ -46,7 +46,7 @@ class Encode extends BaseManipulator
             'jpg' => 'image/jpeg',
             'pjpg' => 'image/jpeg',
             'png' => 'image/png',
-	        'webp' => 'image/webp'
+            'webp' => 'image/webp'
         ];
 
         if (array_key_exists($this->fm, $allowed)) {

--- a/tests/Manipulators/EncodeTest.php
+++ b/tests/Manipulators/EncodeTest.php
@@ -53,9 +53,9 @@ class EncodeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('image/gif', $this->manipulator->setParams(['fm' => 'gif'])->run($this->png)->mime);
         $this->assertSame('image/gif', $this->manipulator->setParams(['fm' => 'gif'])->run($this->gif)->mime);
         $this->assertSame('image/gif', $this->manipulator->setParams(['fm' => 'gif'])->run($this->webp)->mime);
-	    $this->assertSame('image/webp', $this->manipulator->setParams(['fm' => 'webp'])->run($this->jpg)->mime);
-	    $this->assertSame('image/webp', $this->manipulator->setParams(['fm' => 'webp'])->run($this->png)->mime);
-	    $this->assertSame('image/webp', $this->manipulator->setParams(['fm' => 'webp'])->run($this->gif)->mime);
+        $this->assertSame('image/webp', $this->manipulator->setParams(['fm' => 'webp'])->run($this->jpg)->mime);
+        $this->assertSame('image/webp', $this->manipulator->setParams(['fm' => 'webp'])->run($this->png)->mime);
+        $this->assertSame('image/webp', $this->manipulator->setParams(['fm' => 'webp'])->run($this->gif)->mime);
         $this->assertSame('image/webp', $this->manipulator->setParams(['fm' => 'webp'])->run($this->webp)->mime);
     }
 

--- a/tests/Manipulators/EncodeTest.php
+++ b/tests/Manipulators/EncodeTest.php
@@ -12,6 +12,7 @@ class EncodeTest extends \PHPUnit_Framework_TestCase
     private $png;
     private $gif;
     private $tif;
+    private $webp;
 
     public function setUp()
     {
@@ -19,6 +20,7 @@ class EncodeTest extends \PHPUnit_Framework_TestCase
         $this->jpg = $manager->canvas(100, 100)->encode('jpg');
         $this->png = $manager->canvas(100, 100)->encode('png');
         $this->gif = $manager->canvas(100, 100)->encode('gif');
+        $this->webp = $manager->canvas(100, 100)->encode('webp');
 
         $this->manipulator = new Encode();
     }
@@ -38,15 +40,23 @@ class EncodeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('image/jpeg', $this->manipulator->setParams(['fm' => 'jpg'])->run($this->jpg)->mime);
         $this->assertSame('image/jpeg', $this->manipulator->setParams(['fm' => 'jpg'])->run($this->png)->mime);
         $this->assertSame('image/jpeg', $this->manipulator->setParams(['fm' => 'jpg'])->run($this->gif)->mime);
+	    $this->assertSame('image/jpeg', $this->manipulator->setParams(['fm' => 'jpg'])->run($this->webp)->mime);
         $this->assertSame('image/jpeg', $this->manipulator->setParams(['fm' => 'pjpg'])->run($this->jpg)->mime);
         $this->assertSame('image/jpeg', $this->manipulator->setParams(['fm' => 'pjpg'])->run($this->png)->mime);
         $this->assertSame('image/jpeg', $this->manipulator->setParams(['fm' => 'pjpg'])->run($this->gif)->mime);
+        $this->assertSame('image/jpeg', $this->manipulator->setParams(['fm' => 'pjpg'])->run($this->webp)->mime);
         $this->assertSame('image/png', $this->manipulator->setParams(['fm' => 'png'])->run($this->jpg)->mime);
         $this->assertSame('image/png', $this->manipulator->setParams(['fm' => 'png'])->run($this->png)->mime);
         $this->assertSame('image/png', $this->manipulator->setParams(['fm' => 'png'])->run($this->gif)->mime);
+	    $this->assertSame('image/png', $this->manipulator->setParams(['fm' => 'png'])->run($this->webp)->mime);
         $this->assertSame('image/gif', $this->manipulator->setParams(['fm' => 'gif'])->run($this->jpg)->mime);
         $this->assertSame('image/gif', $this->manipulator->setParams(['fm' => 'gif'])->run($this->png)->mime);
         $this->assertSame('image/gif', $this->manipulator->setParams(['fm' => 'gif'])->run($this->gif)->mime);
+	    $this->assertSame('image/gif', $this->manipulator->setParams(['fm' => 'gif'])->run($this->webp)->mime);
+	    $this->assertSame('image/webp', $this->manipulator->setParams(['fm' => 'webp'])->run($this->jpg)->mime);
+	    $this->assertSame('image/webp', $this->manipulator->setParams(['fm' => 'webp'])->run($this->png)->mime);
+	    $this->assertSame('image/webp', $this->manipulator->setParams(['fm' => 'webp'])->run($this->gif)->mime);
+		$this->assertSame('image/webp', $this->manipulator->setParams(['fm' => 'webp'])->run($this->webp)->mime);
     }
 
     public function testGetFormat()
@@ -56,12 +66,14 @@ class EncodeTest extends \PHPUnit_Framework_TestCase
             $mock->shouldReceive('mime')->andReturn('image/png')->once();
             $mock->shouldReceive('mime')->andReturn('image/gif')->once();
             $mock->shouldReceive('mime')->andReturn('image/bmp')->once();
+	        $mock->shouldReceive('mime')->andReturn('image/webp')->once();
             $mock->shouldReceive('mime')->andReturn('image/jpeg')->twice();
         });
 
         $this->assertSame('jpg', $this->manipulator->setParams(['fm' => 'jpg'])->getFormat($image));
         $this->assertSame('png', $this->manipulator->setParams(['fm' => 'png'])->getFormat($image));
         $this->assertSame('gif', $this->manipulator->setParams(['fm' => 'gif'])->getFormat($image));
+	    $this->assertSame('webp', $this->manipulator->setParams(['fm' => 'webp'])->getFormat($image));
         $this->assertSame('jpg', $this->manipulator->setParams(['fm' => null])->getFormat($image));
         $this->assertSame('png', $this->manipulator->setParams(['fm' => null])->getFormat($image));
         $this->assertSame('gif', $this->manipulator->setParams(['fm' => null])->getFormat($image));

--- a/tests/Manipulators/EncodeTest.php
+++ b/tests/Manipulators/EncodeTest.php
@@ -65,8 +65,8 @@ class EncodeTest extends \PHPUnit_Framework_TestCase
             $mock->shouldReceive('mime')->andReturn('image/jpeg')->once();
             $mock->shouldReceive('mime')->andReturn('image/png')->once();
             $mock->shouldReceive('mime')->andReturn('image/gif')->once();
-            $mock->shouldReceive('mime')->andReturn('image/bmp')->once();
             $mock->shouldReceive('mime')->andReturn('image/webp')->once();
+            $mock->shouldReceive('mime')->andReturn('image/bmp')->once();
             $mock->shouldReceive('mime')->andReturn('image/jpeg')->twice();
         });
 
@@ -74,12 +74,14 @@ class EncodeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('png', $this->manipulator->setParams(['fm' => 'png'])->getFormat($image));
         $this->assertSame('gif', $this->manipulator->setParams(['fm' => 'gif'])->getFormat($image));
         $this->assertSame('webp', $this->manipulator->setParams(['fm' => 'webp'])->getFormat($image));
-        $this->assertSame('jpg', $this->manipulator->setParams(['fm' => null])->getFormat($image));
-        $this->assertSame('png', $this->manipulator->setParams(['fm' => null])->getFormat($image));
-        $this->assertSame('gif', $this->manipulator->setParams(['fm' => null])->getFormat($image));
-        $this->assertSame('jpg', $this->manipulator->setParams(['fm' => null])->getFormat($image));
-        $this->assertSame('jpg', $this->manipulator->setParams(['fm' => ''])->getFormat($image));
-        $this->assertSame('jpg', $this->manipulator->setParams(['fm' => 'invalid'])->getFormat($image));
+        // Mock::mime() called from here
+        $this->assertSame('jpg', $this->manipulator->setParams(['fm' => null])->getFormat($image)); // image/jpeg
+        $this->assertSame('png', $this->manipulator->setParams(['fm' => null])->getFormat($image)); // image/png
+        $this->assertSame('gif', $this->manipulator->setParams(['fm' => null])->getFormat($image)); // image/gif
+        $this->assertSame('webp', $this->manipulator->setParams(['fm' => null])->getFormat($image)); // image/webp
+        $this->assertSame('jpg', $this->manipulator->setParams(['fm' => null])->getFormat($image)); // image/bmp
+        $this->assertSame('jpg', $this->manipulator->setParams(['fm' => ''])->getFormat($image)); // image/jpeg
+        $this->assertSame('jpg', $this->manipulator->setParams(['fm' => 'invalid'])->getFormat($image)); // image/jpeg
     }
 
     public function testGetQuality()

--- a/tests/Manipulators/EncodeTest.php
+++ b/tests/Manipulators/EncodeTest.php
@@ -40,7 +40,7 @@ class EncodeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('image/jpeg', $this->manipulator->setParams(['fm' => 'jpg'])->run($this->jpg)->mime);
         $this->assertSame('image/jpeg', $this->manipulator->setParams(['fm' => 'jpg'])->run($this->png)->mime);
         $this->assertSame('image/jpeg', $this->manipulator->setParams(['fm' => 'jpg'])->run($this->gif)->mime);
-	    $this->assertSame('image/jpeg', $this->manipulator->setParams(['fm' => 'jpg'])->run($this->webp)->mime);
+        $this->assertSame('image/jpeg', $this->manipulator->setParams(['fm' => 'jpg'])->run($this->webp)->mime);
         $this->assertSame('image/jpeg', $this->manipulator->setParams(['fm' => 'pjpg'])->run($this->jpg)->mime);
         $this->assertSame('image/jpeg', $this->manipulator->setParams(['fm' => 'pjpg'])->run($this->png)->mime);
         $this->assertSame('image/jpeg', $this->manipulator->setParams(['fm' => 'pjpg'])->run($this->gif)->mime);
@@ -48,15 +48,15 @@ class EncodeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('image/png', $this->manipulator->setParams(['fm' => 'png'])->run($this->jpg)->mime);
         $this->assertSame('image/png', $this->manipulator->setParams(['fm' => 'png'])->run($this->png)->mime);
         $this->assertSame('image/png', $this->manipulator->setParams(['fm' => 'png'])->run($this->gif)->mime);
-	    $this->assertSame('image/png', $this->manipulator->setParams(['fm' => 'png'])->run($this->webp)->mime);
+        $this->assertSame('image/png', $this->manipulator->setParams(['fm' => 'png'])->run($this->webp)->mime);
         $this->assertSame('image/gif', $this->manipulator->setParams(['fm' => 'gif'])->run($this->jpg)->mime);
         $this->assertSame('image/gif', $this->manipulator->setParams(['fm' => 'gif'])->run($this->png)->mime);
         $this->assertSame('image/gif', $this->manipulator->setParams(['fm' => 'gif'])->run($this->gif)->mime);
-	    $this->assertSame('image/gif', $this->manipulator->setParams(['fm' => 'gif'])->run($this->webp)->mime);
+        $this->assertSame('image/gif', $this->manipulator->setParams(['fm' => 'gif'])->run($this->webp)->mime);
 	    $this->assertSame('image/webp', $this->manipulator->setParams(['fm' => 'webp'])->run($this->jpg)->mime);
 	    $this->assertSame('image/webp', $this->manipulator->setParams(['fm' => 'webp'])->run($this->png)->mime);
 	    $this->assertSame('image/webp', $this->manipulator->setParams(['fm' => 'webp'])->run($this->gif)->mime);
-		$this->assertSame('image/webp', $this->manipulator->setParams(['fm' => 'webp'])->run($this->webp)->mime);
+        $this->assertSame('image/webp', $this->manipulator->setParams(['fm' => 'webp'])->run($this->webp)->mime);
     }
 
     public function testGetFormat()
@@ -66,14 +66,14 @@ class EncodeTest extends \PHPUnit_Framework_TestCase
             $mock->shouldReceive('mime')->andReturn('image/png')->once();
             $mock->shouldReceive('mime')->andReturn('image/gif')->once();
             $mock->shouldReceive('mime')->andReturn('image/bmp')->once();
-	        $mock->shouldReceive('mime')->andReturn('image/webp')->once();
+            $mock->shouldReceive('mime')->andReturn('image/webp')->once();
             $mock->shouldReceive('mime')->andReturn('image/jpeg')->twice();
         });
 
         $this->assertSame('jpg', $this->manipulator->setParams(['fm' => 'jpg'])->getFormat($image));
         $this->assertSame('png', $this->manipulator->setParams(['fm' => 'png'])->getFormat($image));
         $this->assertSame('gif', $this->manipulator->setParams(['fm' => 'gif'])->getFormat($image));
-	    $this->assertSame('webp', $this->manipulator->setParams(['fm' => 'webp'])->getFormat($image));
+        $this->assertSame('webp', $this->manipulator->setParams(['fm' => 'webp'])->getFormat($image));
         $this->assertSame('jpg', $this->manipulator->setParams(['fm' => null])->getFormat($image));
         $this->assertSame('png', $this->manipulator->setParams(['fm' => null])->getFormat($image));
         $this->assertSame('gif', $this->manipulator->setParams(['fm' => null])->getFormat($image));


### PR DESCRIPTION
This adds support for webp images.  

Intervention now has support for it
https://github.com/Intervention/image/commit/dccbee2e9dbde41b8b82deadd38fa574fc853689  
https://github.com/Intervention/image/commit/baeeac5125b7015f3fad0f9333b5e33585430f38  
https://github.com/Intervention/image/commit/961c58a9951acd688b9a2d17ff24ac9bcb199f84

I've added some tests for webp to EncodeTest.php but since I'm not to familiar with it I don't know if they're  right/good etc :)  

the docs (http://glide.thephpleague.com/1.0/api/encode/) will need a corresponding update as well  

related: https://github.com/thephpleague/glide/issues/118

