### PR TITLE
make sure to unlink tmpfile when a FilesystemException is thrown

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -517,6 +517,8 @@ class Server
         $tmp = tempnam(sys_get_temp_dir(), 'Glide');
 
         if (file_put_contents($tmp, $source) === false) {
+            unlink($tmp);
+            
             throw new FilesystemException(
                 'Unable to write temp file for `'.$sourcePath.'`.'
             );
@@ -529,6 +531,8 @@ class Server
             );
 
             if ($write === false) {
+                unlink($tmp);
+                
                 throw new FilesystemException(
                     'Could not write the image `'.$cachedPath.'`.'
                 );


### PR DESCRIPTION
Fixes an issue with tmpfiles not being deleted in the cases where either the tmpfile could not be written to, or when writing the processed image.