### PR TITLE
Number format of alpha part in Color

### DIFF
--- a/src/Manipulators/Helpers/Color.php
+++ b/src/Manipulators/Helpers/Color.php
@@ -113,8 +113,8 @@ class Color
     {
         // Make sure the alpha float is correctly formatted
         $formatted = number_format($this->alpha, 2, '.', ',');
-		$zero_trimmed = rtrim($formatted, '0');
-		$alpha_str = rtrim($zero_trimmed, '.');
+        $zero_trimmed = rtrim($formatted, '0');
+        $alpha_str = rtrim($zero_trimmed, '.');
 
         return 'rgba('.$this->red.', '.$this->green.', '.$this->blue.', '.$alpha_str.')';
     }

--- a/src/Manipulators/Helpers/Color.php
+++ b/src/Manipulators/Helpers/Color.php
@@ -111,7 +111,10 @@ class Color
      */
     public function formatted()
     {
-        return 'rgba('.$this->red.', '.$this->green.', '.$this->blue.', '.$this->alpha.')';
+        // Make sure the alpha float is correctly formatted
+        $alpha_str = number_format($this->alpha, 2, '.', ',');
+
+        return 'rgba('.$this->red.', '.$this->green.', '.$this->blue.', '.$alpha_str.')';
     }
 
     /**

--- a/src/Manipulators/Helpers/Color.php
+++ b/src/Manipulators/Helpers/Color.php
@@ -112,7 +112,9 @@ class Color
     public function formatted()
     {
         // Make sure the alpha float is correctly formatted
-        $alpha_str = number_format($this->alpha, 2, '.', ',');
+        $formatted = number_format($this->alpha, 2, '.', ',');
+		$zero_trimmed = rtrim($formatted, '0');
+		$alpha_str = rtrim($zero_trimmed, '.');
 
         return 'rgba('.$this->red.', '.$this->green.', '.$this->blue.', '.$alpha_str.')';
     }

--- a/tests/Manipulators/Helpers/ColorTest.php
+++ b/tests/Manipulators/Helpers/ColorTest.php
@@ -45,4 +45,12 @@ class ColorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('rgba(255, 255, 255, 0)', $color->formatted());
     }
+
+    public function testAlphaFloat()
+    {
+        $color = new Color('55CCCCCC');
+
+        $this->assertSame('rgba(204, 204, 204, 0.55)', $color->formatted());
+    }
+
 }


### PR DESCRIPTION
When casting a float to string, PHP respects the locale it is in. This means that the float 0.55 is casted to "0.55" in USA (probably loads more countries, but that is beside the point), but where I live (Netherlands), it becomes "0,55".
This means that, when the input is "55CCCCCC", Color::formatted() outputs 'rgba(204, 204, 204, 0,55)', which in turn is interpreted as 'rgba(204, 204, 204, 0, 55)' (a fifth argument has appeared).

The fix I wrote makes sure that this float is always written as "0.55". Old behaviour is respected: 0.5 becomes "0.5" and 0 becomes "0".