### PR TITLE
Ignore notices raised by tempnam

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -514,7 +514,7 @@ class Server
         // We need to write the image to the local disk before
         // doing any manipulations. This is because EXIF data
         // can only be read from an actual file.
-        $tmp = tempnam(sys_get_temp_dir(), 'Glide');
+        $tmp = @tempnam(sys_get_temp_dir(), 'Glide');
 
         if (file_put_contents($tmp, $source) === false) {
             throw new FilesystemException(


### PR DESCRIPTION
Since PHP 7.1, tempnam sometimes raise notices to alert when a unexpected behavior is used as a fallback (https://bugs.php.net/bug.php?id=69489).

As this notice isn't much of a problem in Glide (we need the file to be created in the system temporary directory anyway), we can safely ignore these notices.

This notice happens regularly on my Symfony application (and as Symfony catches it in dev, it breaks the page).