### PR TITLE
Always delete tmp file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
   - COMPOSER_OPTS="--prefer-lowest"
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "intervention/image": "^2.1",
         "league/flysystem": "^1.0",
-        "php": "^5.4 | ^7.0",
+        "php": "^5.5 | ^7.0",
         "psr/http-message": "^1.0"
     },
     "require-dev": {

--- a/src/Server.php
+++ b/src/Server.php
@@ -537,9 +537,9 @@ class Server
             // This edge case occurs when the target already exists
             // because it's currently be written to disk in another
             // request. It's best to just fail silently.
+        } finally {
+            unlink($tmp);
         }
-
-        unlink($tmp);
 
         return $cachedPath;
     }


### PR DESCRIPTION
If an exception occurs during this try/catch (eg. invalid file type, file too large etc), the /tmp/GlideXXX files will not be deleted. This will fill the /tmp folder and can lead to problems when it's not deleted regularly.

Should fix https://github.com/thephpleague/glide/issues/192 