### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,20 @@ env:
   - COMPOSER_OPTS="--prefer-lowest"
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+
+matrix:
+  include:
+    - php: 5.5
+      env: COMPOSER_OPTS=""
+      dist: trusty
+    - php: 5.5
+      env: COMPOSER_OPTS="--prefer-lowest"
+      dist: trusty
 
 cache:
   directories:
@@ -24,7 +33,7 @@ install:
   - travis_retry composer update --no-interaction --prefer-source
 
 script:
-  - phpunit --coverage-text --coverage-clover=coverage.clover
+  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar


### PR DESCRIPTION
Three changes to `.travis.yml`:

* Add PHP 7.3 to the build matrix.
* The default environment on TravisCI [changed](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment) from `trusty` to `xenial` in April 2019.  This means that PHP 5.5 won't build unless we explicitly choose the older environment.
* Explicitly use our own version of `phpunit`.  Otherwise some builds pick up an incompatible version from the environment.

