### PR TITLE
FIX: resizeCanvas() accepts only integer

### DIFF
--- a/src/Manipulators/Border.php
+++ b/src/Manipulators/Border.php
@@ -56,7 +56,7 @@ class Border extends BaseManipulator
         $method = $this->getMethod(isset($values[2]) ? $values[2] : null);
 
         if ($width) {
-            return [$width, $color, $method];
+            return [round($width), $color, $method];
         }
     }
 


### PR DESCRIPTION
FIX: resizeCanvas() accepts only integer

Sample border parameter that causes the error
```
border=10w,FFCC33,shrink
```

The error: 
resizeCanvas() accepts only integer values as argument 1.

The solution: 
Rounding the value of width in \League\Glide\Manipulators\Border->getBorder() method.
