### PR TITLE
Custom path callable

### DIFF
--- a/docs/1.0/config/setup.md
+++ b/docs/1.0/config/setup.md
@@ -21,6 +21,7 @@ $server = League\Glide\ServerFactory::create([
     'cache_path_prefix' =>       // Cache filesystem path prefix
     'temp_dir' =>                // Temporary directory where cache EXIF data should be stored 
                                  // (defaults to sys_get_temp_dir())
+    'cache_path_callable' =>     // Custom cache path callable
     'group_cache_in_folders' =>  // Whether to group cached images in folders
     'watermarks' =>              // Watermarks filesystem
     'watermarks_path_prefix' =>  // Watermarks filesystem path prefix

--- a/src/Server.php
+++ b/src/Server.php
@@ -376,10 +376,10 @@ class Server
     public function getCachePath($path, array $params = [])
     {
         $customCallable = $this->getCachePathCallable();
-        if ($customCallable instanceof \Closure) {
+        if (null !== $customCallable) {
             $boundCallable = \Closure::bind($customCallable, $this, self::class);
 
-            return $boundCallable(...func_get_args());
+            return $boundCallable($path, $params);
         }
         $sourcePath = $this->getSourcePath($path);
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -98,7 +98,7 @@ class Server
     /**
      * Custom cache path callable.
      *
-     * @var callable|null
+     * @var \Closure|null
      */
     protected $cachePathCallable;
 
@@ -348,9 +348,9 @@ class Server
     /**
      * Set a custom cachePathCallable.
      *
-     * @param callable|null $cachePathCallable The custom cache path callable. It receives the same arguments as @see getCachePath
+     * @param \Closure|null $cachePathCallable The custom cache path callable. It receives the same arguments as @see getCachePath
      */
-    public function setCachePathCallable($cachePathCallable)
+    public function setCachePathCallable(?\Closure $cachePathCallable)
     {
         $this->cachePathCallable = $cachePathCallable;
     }
@@ -358,7 +358,7 @@ class Server
     /**
      * Gets the custom cachePathCallable.
      *
-     * @return callable|null The custom cache path callable. It receives the same arguments as @see getCachePath
+     * @return \Closure|null The custom cache path callable. It receives the same arguments as @see getCachePath
      */
     public function getCachePathCallable()
     {
@@ -376,7 +376,7 @@ class Server
     public function getCachePath($path, array $params = [])
     {
         $customCallable = $this->getCachePathCallable();
-        if (is_callable($customCallable)) {
+        if ($customCallable instanceof \Closure) {
             $boundCallable = \Closure::bind($customCallable, $this, self::class);
 
             return $boundCallable(...func_get_args());

--- a/src/Server.php
+++ b/src/Server.php
@@ -97,6 +97,7 @@ class Server
     protected $presets = [];
     /**
      * Custom cache path callable.
+     *
      * @var callable|null
      */
     protected $cachePathCallable;
@@ -345,7 +346,8 @@ class Server
     }
 
     /**
-     * Set a custom cachePathCallable
+     * Set a custom cachePathCallable.
+     *
      * @param callable|null $cachePathCallable The custom cache path callable. It receives the same arguments as @see getCachePath
      */
     public function setCachePathCallable($cachePathCallable)
@@ -354,7 +356,8 @@ class Server
     }
 
     /**
-     * Gets the custom cachePathCallable
+     * Gets the custom cachePathCallable.
+     *
      * @return callable|null The custom cache path callable. It receives the same arguments as @see getCachePath
      */
     public function getCachePathCallable()
@@ -375,6 +378,7 @@ class Server
         $customCallable = $this->getCachePathCallable();
         if (is_callable($customCallable)) {
             $boundCallable = \Closure::bind($customCallable, $this, self::class);
+
             return $boundCallable(...func_get_args());
         }
         $sourcePath = $this->getSourcePath($path);
@@ -688,4 +692,3 @@ class Server
         return $cachedPath;
     }
 }
-

--- a/src/Server.php
+++ b/src/Server.php
@@ -95,6 +95,11 @@ class Server
      * @var array
      */
     protected $presets = [];
+    /**
+     * Custom cache path callable.
+     * @var callable|null
+     */
+    protected $cachePathCallable;
 
     /**
      * Create Server instance.
@@ -340,6 +345,24 @@ class Server
     }
 
     /**
+     * Set a custom cachePathCallable
+     * @param callable|null $cachePathCallable The custom cache path callable. It receives the same arguments as @see getCachePath
+     */
+    public function setCachePathCallable($cachePathCallable)
+    {
+        $this->cachePathCallable = $cachePathCallable;
+    }
+
+    /**
+     * Gets the custom cachePathCallable
+     * @return callable|null The custom cache path callable. It receives the same arguments as @see getCachePath
+     */
+    public function getCachePathCallable()
+    {
+        return $this->cachePathCallable;
+    }
+
+    /**
      * Get cache path.
      *
      * @param string $path   Image path.
@@ -349,6 +372,11 @@ class Server
      */
     public function getCachePath($path, array $params = [])
     {
+        $customCallable = $this->getCachePathCallable();
+        if (is_callable($customCallable)) {
+            $boundCallable = \Closure::bind($customCallable, $this, self::class);
+            return $boundCallable(...func_get_args());
+        }
         $sourcePath = $this->getSourcePath($path);
 
         if ($this->sourcePathPrefix) {
@@ -660,3 +688,4 @@ class Server
         return $cachedPath;
     }
 }
+

--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -65,6 +65,7 @@ class ServerFactory
         $server->setPresets($this->getPresets());
         $server->setBaseUrl($this->getBaseUrl());
         $server->setResponseFactory($this->getResponseFactory());
+        $server->setCachePathCallable($this->getCachePathCallable());
 
         if ($this->getTempDir()) {
             $server->setTempDir($this->getTempDir());
@@ -146,6 +147,17 @@ class ServerFactory
     {
         if (isset($this->config['temp_dir'])) {
             return $this->config['temp_dir'];
+        }
+    }
+
+    /**
+     * Get cache path callable.
+     * @return callable|null Cache path callable.
+     */
+    public function getCachePathCallable()
+    {
+        if (isset($this->config['cache_path_callable'])) {
+            return $this->config['cache_path_callable'];
         }
     }
 

--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -157,9 +157,7 @@ class ServerFactory
      */
     public function getCachePathCallable()
     {
-        if (isset($this->config['cache_path_callable'])) {
-            return $this->config['cache_path_callable'];
-        }
+        return $this->config['cache_path_callable'] ?? null;
     }
 
     /**

--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -152,6 +152,7 @@ class ServerFactory
 
     /**
      * Get cache path callable.
+     *
      * @return callable|null Cache path callable.
      */
     public function getCachePathCallable()

--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -153,7 +153,7 @@ class ServerFactory
     /**
      * Get cache path callable.
      *
-     * @return callable|null Cache path callable.
+     * @return \Closure|null Cache path callable.
      */
     public function getCachePathCallable()
     {

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -151,7 +151,58 @@ class ServerTest extends TestCase
     public function testSetGetTempDir()
     {
         $this->server->setTempDir(__DIR__);
-        $this->assertSame(__DIR__.DIRECTORY_SEPARATOR, $this->server->getTempDir());
+        $this->assertSame(__DIR__ . DIRECTORY_SEPARATOR, $this->server->getTempDir());
+    }
+
+    public function testSetCachePathCallable()
+    {
+        $this->server->setCachePathCallable(null);
+        $this->assertEquals(null, $this->server->getCachePathCallable());
+    }
+
+    public function testGetCachePathCallable()
+    {
+        $this->assertEquals(null, $this->server->getCachePathCallable());
+    }
+
+    public function testCachePathCallableIsCalledOnGetCachePath()
+    {
+        $expected = 'TEST';
+        $callable = function () use ($expected) {
+            return $expected;
+        };
+
+        $this->server->setCachePathCallable($callable);
+
+        self::assertEquals($expected, $this->server->getCachePath(''));
+    }
+
+    public function testSetCachePathCallableIsBoundClosure()
+    {
+        $server  = $this->server;
+        $phpUnit = $this;
+        $this->server->setCachePathCallable(function () use ($phpUnit, $server) {
+            $phpUnit::assertEquals($server, $this);
+        });
+
+        $this->server->getCachePath('');
+    }
+
+    public function testSetCachePathCallableArgumentsAreSameAsGetCachePath()
+    {
+        $phpUnit         = $this;
+        $pathArgument    = 'TEST';
+        $optionsArgument = [
+            'TEST' => 'TEST',
+        ];
+        $this->server->setCachePathCallable(function () use ($optionsArgument, $pathArgument, $phpUnit) {
+            $arguments = func_get_args();
+            $phpUnit::assertCount(2, $arguments);
+            $phpUnit::assertEquals($arguments[0], $pathArgument);
+            $phpUnit::assertEquals($arguments[1], $optionsArgument);
+        });
+
+        $this->server->getCachePath($pathArgument, $optionsArgument);
     }
 
     public function testSetGroupCacheInFolders()

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -151,7 +151,7 @@ class ServerTest extends TestCase
     public function testSetGetTempDir()
     {
         $this->server->setTempDir(__DIR__);
-        $this->assertSame(__DIR__ . DIRECTORY_SEPARATOR, $this->server->getTempDir());
+        $this->assertSame(__DIR__.DIRECTORY_SEPARATOR, $this->server->getTempDir());
     }
 
     public function testSetCachePathCallable()
@@ -179,7 +179,7 @@ class ServerTest extends TestCase
 
     public function testSetCachePathCallableIsBoundClosure()
     {
-        $server  = $this->server;
+        $server = $this->server;
         $phpUnit = $this;
         $this->server->setCachePathCallable(function () use ($phpUnit, $server) {
             $phpUnit::assertEquals($server, $this);
@@ -190,8 +190,8 @@ class ServerTest extends TestCase
 
     public function testSetCachePathCallableArgumentsAreSameAsGetCachePath()
     {
-        $phpUnit         = $this;
-        $pathArgument    = 'TEST';
+        $phpUnit = $this;
+        $pathArgument = 'TEST';
         $optionsArgument = [
             'TEST' => 'TEST',
         ];


### PR DESCRIPTION
This would allow to customize the cache path fully.

An alternative would be to call the callable at the end of getCachePath with all the calculated parts (sourcePath, md5, groupCacheInFolders, cachePathPrefix, cacheWithFileExtensions, ext).

I also bound this to the Server instance so that we may its method within the callable.