### PR TITLE
Flysystem v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "intervention/image": "^2.4",
-        "league/flysystem": "^1.0",
+        "league/flysystem": "^1.0|^2.0",
         "php": "^7.2|^8.0",
         "psr/http-message": "^1.0"
     },

--- a/src/Manipulators/Watermark.php
+++ b/src/Manipulators/Watermark.php
@@ -165,7 +165,7 @@ class Watermark extends BaseManipulator
 
                 return $image->getDriver()->init($source);
             }
-        }catch (V2FilesystemException $exception) {
+        } catch (V2FilesystemException $exception) {
             throw new FilesystemException(
                 'Could not read the image `'.$path.'`.'
             );

--- a/src/Responses/Flysystem2ResponseFactoryInterface.php
+++ b/src/Responses/Flysystem2ResponseFactoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace League\Glide\Responses;
+
+use League\Flysystem\FilesystemOperator;
+
+interface Flysystem2ResponseFactoryInterface
+{
+    /**
+     * Create response.
+     * @param  FilesystemOperator  $cache Cache file system.
+     * @param  string              $path  Cached file path.
+     * @return mixed               The response object.
+     */
+    public function createFlysystem2(FilesystemOperator $cache, $path);
+}

--- a/src/Server.php
+++ b/src/Server.php
@@ -163,7 +163,7 @@ class Server
      */
     public function sourceFileExists($path)
     {
-        if($this->source instanceof FilesystemInterface) {
+        if ($this->source instanceof FilesystemInterface) {
             return $this->source->has($this->getSourcePath($path));
         }
 
@@ -303,7 +303,7 @@ class Server
      */
     public function cacheFileExists($path, array $params)
     {
-        if($this->cache instanceof FilesystemInterface) {
+        if ($this->cache instanceof FilesystemInterface) {
             return $this->cache->has(
                 $this->getCachePath($path, $params)
             );
@@ -327,7 +327,7 @@ class Server
             );
         }
 
-        if($this->cache instanceof FilesystemInterface) {
+        if ($this->cache instanceof FilesystemInterface) {
             return $this->cache->deleteDir(
                 dirname($this->getCachePath($path))
             );
@@ -473,7 +473,7 @@ class Server
             );
         }
 
-        if($this->cache instanceof FilesystemInterface) {
+        if ($this->cache instanceof FilesystemInterface) {
             return 'data:'.$this->cache->getMimetype($path).';base64,'.base64_encode($source);
         }
 
@@ -490,7 +490,7 @@ class Server
     {
         $path = $this->makeImage($path, $params);
 
-        if($this->cache instanceof FilesystemInterface) {
+        if ($this->cache instanceof FilesystemInterface) {
             header('Content-Type:'.$this->cache->getMimetype($path));
             header('Content-Length:'.$this->cache->getSize($path));
         } else {

--- a/src/Server.php
+++ b/src/Server.php
@@ -463,7 +463,7 @@ class Server
 
         try {
             $source = $this->cache->read($path);
-        }catch(UnableToReadFile $exception) {
+        } catch (UnableToReadFile $exception) {
             $source = false;
         }
 

--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -75,7 +75,7 @@ class ServerFactory
      */
     private function createLocalFilesystem(string $path)
     {
-        if(interface_exists(FilesystemInterface::class)) {
+        if (interface_exists(FilesystemInterface::class)) {
             return new Filesystem(
                 new Local($path)
             );

--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -7,6 +7,8 @@ use InvalidArgumentException;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemInterface;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 use League\Glide\Api\Api;
 use League\Glide\Manipulators\Background;
 use League\Glide\Manipulators\Blur;
@@ -67,8 +69,26 @@ class ServerFactory
     }
 
     /**
+     * Create local filesystem for Flysystem v1 or v2
+     * @param  string  $path Filesystem path
+     * @return FilesystemInterface|FilesystemOperator
+     */
+    private function createLocalFilesystem(string $path)
+    {
+        if(interface_exists(FilesystemInterface::class)) {
+            return new Filesystem(
+                new Local($path)
+            );
+        }
+
+        return new Filesystem(
+            new LocalFilesystemAdapter($path)
+        );
+    }
+
+    /**
      * Get source file system.
-     * @return FilesystemInterface Source file system.
+     * @return FilesystemInterface|FilesystemOperator Source file system.
      */
     public function getSource()
     {
@@ -77,9 +97,7 @@ class ServerFactory
         }
 
         if (is_string($this->config['source'])) {
-            return new Filesystem(
-                new Local($this->config['source'])
-            );
+            return $this->createLocalFilesystem($this->config['source']);
         }
 
         return $this->config['source'];
@@ -98,7 +116,7 @@ class ServerFactory
 
     /**
      * Get cache file system.
-     * @return FilesystemInterface Cache file system.
+     * @return FilesystemInterface|FilesystemOperator Cache file system.
      */
     public function getCache()
     {
@@ -107,9 +125,7 @@ class ServerFactory
         }
 
         if (is_string($this->config['cache'])) {
-            return new Filesystem(
-                new Local($this->config['cache'])
-            );
+            return $this->createLocalFilesystem($this->config['cache']);
         }
 
         return $this->config['cache'];
@@ -154,7 +170,7 @@ class ServerFactory
 
     /**
      * Get watermarks file system.
-     * @return FilesystemInterface|null Watermarks file system.
+     * @return FilesystemInterface|FilesystemOperator|null Watermarks file system.
      */
     public function getWatermarks()
     {
@@ -163,9 +179,7 @@ class ServerFactory
         }
 
         if (is_string($this->config['watermarks'])) {
-            return new Filesystem(
-                new Local($this->config['watermarks'])
-            );
+            return $this->createLocalFilesystem($this->config['watermarks']);
         }
 
         return $this->config['watermarks'];


### PR DESCRIPTION
This is alternative approach to Flysystem v2 integration based on discussion in #291.

For now it's just a draft as none of the tests are refactored to handle new interfaces. Before touching them I'd love to hear opinions about code changes. I had no idea for better `ResponseFactoryInterface`, open to suggestions.

One important thing I might have missed some place is exception handling - Flysystem v2 changed a lot and now throws exceptions instead of returning `false`. I've tried to adapt to it, but probably missed a place or two.

And question about tests - how to proceed? Shall I detect available Flysystem version and check against available interfaces or write new tests for Flysystem v2 and skip those unavailable? Or maybe some other way? I think checking available interfaces is the way to go as we can then set up CI jobs to test against different Flysystem versions, but I might be wrong.