### PR TITLE
Use only Flysystem v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "intervention/image": "^2.4",
-        "league/flysystem": "^1.0",
+        "league/flysystem": "^2.0",
         "psr/http-message": "^1.0"
     },
     "require-dev": {

--- a/docs/1.0/config/advanced-usage.md
+++ b/docs/1.0/config/advanced-usage.md
@@ -13,7 +13,7 @@ Once your Glide [server](/1.0/config/setup/) is configured, there are a number o
 <?php
 
 // Set the source file system
-public function setSource(FilesystemInterface $source)
+public function setSource(FilesystemOperator $source)
 
 // Get the source file system
 public function getSource()
@@ -37,7 +37,7 @@ public function sourceFileExists($path)
 <?php
 
 // Set the cache file system
-public function setCache(FilesystemInterface $cache)
+public function setCache(FilesystemOperator $cache)
 
 // Get the cache file system
 public function getCache()

--- a/docs/1.0/config/responses.md
+++ b/docs/1.0/config/responses.md
@@ -29,16 +29,16 @@ If your particular project doesn't use PSR-7 or HttpFoundation, or if you'd like
 
 namespace League\Glide\Responses;
 
-use League\Flysystem\FilesystemInterface;
+use League\Flysystem\FilesystemOperator;
 
 interface ResponseFactoryInterface
 {
     /**
      * Create the response.
-     * @param  FilesystemInterface $cache The cache file system.
+     * @param  FilesystemOperator $cache The cache file system.
      * @param  string              $path  The cached file path.
      * @return mixed               The response object.
      */
-    public function create(FilesystemInterface $cache, $path);
+    public function create(FilesystemOperator $cache, $path);
 }
 ~~~

--- a/src/Manipulators/Watermark.php
+++ b/src/Manipulators/Watermark.php
@@ -3,7 +3,7 @@
 namespace League\Glide\Manipulators;
 
 use Intervention\Image\Image;
-use League\Flysystem\FilesystemInterface;
+use League\Flysystem\FilesystemOperator;
 use League\Glide\Filesystem\FilesystemException;
 use League\Glide\Manipulators\Helpers\Dimension;
 
@@ -24,7 +24,7 @@ class Watermark extends BaseManipulator
     /**
      * The watermarks file system.
      *
-     * @var FilesystemInterface|null
+     * @var FilesystemOperator|null
      */
     protected $watermarks;
 
@@ -38,9 +38,9 @@ class Watermark extends BaseManipulator
     /**
      * Create Watermark instance.
      *
-     * @param FilesystemInterface $watermarks The watermarks file system.
+     * @param FilesystemOperator $watermarks The watermarks file system.
      */
-    public function __construct(FilesystemInterface $watermarks = null, $watermarksPathPrefix = '')
+    public function __construct(FilesystemOperator $watermarks = null, $watermarksPathPrefix = '')
     {
         $this->setWatermarks($watermarks);
         $this->setWatermarksPathPrefix($watermarksPathPrefix);
@@ -49,9 +49,9 @@ class Watermark extends BaseManipulator
     /**
      * Set the watermarks file system.
      *
-     * @param FilesystemInterface $watermarks The watermarks file system.
+     * @param FilesystemOperator $watermarks The watermarks file system.
      */
-    public function setWatermarks(FilesystemInterface $watermarks = null)
+    public function setWatermarks(FilesystemOperator $watermarks = null)
     {
         $this->watermarks = $watermarks;
     }
@@ -59,7 +59,7 @@ class Watermark extends BaseManipulator
     /**
      * Get the watermarks file system.
      *
-     * @return FilesystemInterface The watermarks file system.
+     * @return FilesystemOperator The watermarks file system.
      */
     public function getWatermarks()
     {
@@ -154,7 +154,7 @@ class Watermark extends BaseManipulator
             $path = $this->watermarksPathPrefix.'/'.$path;
         }
 
-        if ($this->watermarks->has($path)) {
+        if ($this->watermarks->fileExists($path)) {
             $source = $this->watermarks->read($path);
 
             if (false === $source) {

--- a/src/Manipulators/Watermark.php
+++ b/src/Manipulators/Watermark.php
@@ -162,9 +162,7 @@ class Watermark extends BaseManipulator
                 return $image->getDriver()->init($source);
             }
         } catch (FilesystemV2Exception $exception) {
-            throw new FilesystemException(
-                'Could not read the image `'.$path.'`.'
-            );
+            throw new FilesystemException('Could not read the image `'.$path.'`.');
         }
     }
 

--- a/src/Manipulators/Watermark.php
+++ b/src/Manipulators/Watermark.php
@@ -3,6 +3,7 @@
 namespace League\Glide\Manipulators;
 
 use Intervention\Image\Image;
+use League\Flysystem\FilesystemException as FilesystemV2Exception;
 use League\Flysystem\FilesystemOperator;
 use League\Glide\Filesystem\FilesystemException;
 use League\Glide\Manipulators\Helpers\Dimension;
@@ -154,14 +155,16 @@ class Watermark extends BaseManipulator
             $path = $this->watermarksPathPrefix.'/'.$path;
         }
 
-        if ($this->watermarks->fileExists($path)) {
-            $source = $this->watermarks->read($path);
+        try {
+            if ($this->watermarks->fileExists($path)) {
+                $source = $this->watermarks->read($path);
 
-            if (false === $source) {
-                throw new FilesystemException('Could not read the image `'.$path.'`.');
+                return $image->getDriver()->init($source);
             }
-
-            return $image->getDriver()->init($source);
+        } catch (FilesystemV2Exception $exception) {
+            throw new FilesystemException(
+                'Could not read the image `'.$path.'`.'
+            );
         }
     }
 

--- a/src/Responses/PsrResponseFactory.php
+++ b/src/Responses/PsrResponseFactory.php
@@ -39,7 +39,7 @@ class PsrResponseFactory implements ResponseFactoryInterface
      * Create response.
      *
      * @param FilesystemOperator $cache Cache file system.
-     * @param string              $path  Cached file path.
+     * @param string             $path  Cached file path.
      *
      * @return ResponseInterface Response object.
      */

--- a/src/Responses/PsrResponseFactory.php
+++ b/src/Responses/PsrResponseFactory.php
@@ -3,7 +3,7 @@
 namespace League\Glide\Responses;
 
 use Closure;
-use League\Flysystem\FilesystemInterface;
+use League\Flysystem\FilesystemOperator;
 use League\Glide\Filesystem\FilesystemException;
 use Psr\Http\Message\ResponseInterface;
 
@@ -38,19 +38,19 @@ class PsrResponseFactory implements ResponseFactoryInterface
     /**
      * Create response.
      *
-     * @param FilesystemInterface $cache Cache file system.
+     * @param FilesystemOperator $cache Cache file system.
      * @param string              $path  Cached file path.
      *
      * @return ResponseInterface Response object.
      */
-    public function create(FilesystemInterface $cache, $path)
+    public function create(FilesystemOperator $cache, $path)
     {
         $stream = $this->streamCallback->__invoke(
             $cache->readStream($path)
         );
 
-        $contentType = $cache->getMimetype($path);
-        $contentLength = (string) $cache->getSize($path);
+        $contentType = $cache->mimeType($path);
+        $contentLength = (string) $cache->fileSize($path);
         $cacheControl = 'max-age=31536000, public';
         $expires = date_create('+1 years')->format('D, d M Y H:i:s').' GMT';
 

--- a/src/Responses/ResponseFactoryInterface.php
+++ b/src/Responses/ResponseFactoryInterface.php
@@ -2,17 +2,17 @@
 
 namespace League\Glide\Responses;
 
-use League\Flysystem\FilesystemInterface;
+use League\Flysystem\FilesystemOperator;
 
 interface ResponseFactoryInterface
 {
     /**
      * Create response.
      *
-     * @param FilesystemInterface $cache Cache file system.
+     * @param FilesystemOperator $cache Cache file system.
      * @param string              $path  Cached file path.
      *
      * @return mixed The response object.
      */
-    public function create(FilesystemInterface $cache, $path);
+    public function create(FilesystemOperator $cache, $path);
 }

--- a/src/Responses/ResponseFactoryInterface.php
+++ b/src/Responses/ResponseFactoryInterface.php
@@ -10,7 +10,7 @@ interface ResponseFactoryInterface
      * Create response.
      *
      * @param FilesystemOperator $cache Cache file system.
-     * @param string              $path  Cached file path.
+     * @param string             $path  Cached file path.
      *
      * @return mixed The response object.
      */

--- a/src/Server.php
+++ b/src/Server.php
@@ -3,8 +3,8 @@
 namespace League\Glide;
 
 use InvalidArgumentException;
-use League\Flysystem\FileExistsException;
-use League\Flysystem\FilesystemInterface;
+use League\Flysystem\FilesystemException as FilesystemV2Exception;
+use League\Flysystem\FilesystemOperator;
 use League\Glide\Api\ApiInterface;
 use League\Glide\Filesystem\FileNotFoundException;
 use League\Glide\Filesystem\FilesystemException;
@@ -15,7 +15,7 @@ class Server
     /**
      * Source file system.
      *
-     * @var FilesystemInterface
+     * @var FilesystemOperator
      */
     protected $source;
 
@@ -29,7 +29,7 @@ class Server
     /**
      * Cache file system.
      *
-     * @var FilesystemInterface
+     * @var FilesystemOperator
      */
     protected $cache;
 
@@ -99,11 +99,11 @@ class Server
     /**
      * Create Server instance.
      *
-     * @param FilesystemInterface $source Source file system.
-     * @param FilesystemInterface $cache  Cache file system.
+     * @param FilesystemOperator  $source Source file system.
+     * @param FilesystemOperator  $cache  Cache file system.
      * @param ApiInterface        $api    Image manipulation API.
      */
-    public function __construct(FilesystemInterface $source, FilesystemInterface $cache, ApiInterface $api)
+    public function __construct(FilesystemOperator $source, FilesystemOperator $cache, ApiInterface $api)
     {
         $this->setSource($source);
         $this->setCache($cache);
@@ -114,9 +114,9 @@ class Server
     /**
      * Set source file system.
      *
-     * @param FilesystemInterface $source Source file system.
+     * @param FilesystemOperator $source Source file system.
      */
-    public function setSource(FilesystemInterface $source)
+    public function setSource(FilesystemOperator $source)
     {
         $this->source = $source;
     }
@@ -124,7 +124,7 @@ class Server
     /**
      * Get source file system.
      *
-     * @return FilesystemInterface Source file system.
+     * @return FilesystemOperator Source file system.
      */
     public function getSource()
     {
@@ -190,7 +190,7 @@ class Server
      */
     public function sourceFileExists($path)
     {
-        return $this->source->has($this->getSourcePath($path));
+        return $this->source->fileExists($this->getSourcePath($path));
     }
 
     /**
@@ -216,9 +216,9 @@ class Server
     /**
      * Set cache file system.
      *
-     * @param FilesystemInterface $cache Cache file system.
+     * @param FilesystemOperator $cache Cache file system.
      */
-    public function setCache(FilesystemInterface $cache)
+    public function setCache(FilesystemOperator $cache)
     {
         $this->cache = $cache;
     }
@@ -226,7 +226,7 @@ class Server
     /**
      * Get cache file system.
      *
-     * @return FilesystemInterface Cache file system.
+     * @return FilesystemOperator Cache file system.
      */
     public function getCache()
     {
@@ -366,7 +366,7 @@ class Server
      */
     public function cacheFileExists($path, array $params)
     {
-        return $this->cache->has(
+        return $this->cache->fileExists(
             $this->getCachePath($path, $params)
         );
     }
@@ -384,9 +384,15 @@ class Server
             throw new InvalidArgumentException('Deleting cached image manipulations is not possible when grouping cache into folders is disabled.');
         }
 
-        return $this->cache->deleteDir(
-            dirname($this->getCachePath($path))
-        );
+        try{
+            $this->cache->deleteDirectory(
+                dirname($this->getCachePath($path))
+            );
+
+            return true;
+        } catch (FilesystemV2Exception $exception) {
+            return false;
+        }
     }
 
     /**
@@ -532,7 +538,7 @@ class Server
             throw new FilesystemException('Could not read the image `'.$path.'`.');
         }
 
-        return 'data:'.$this->cache->getMimetype($path).';base64,'.base64_encode($source);
+        return 'data:'.$this->cache->mimeType($path).';base64,'.base64_encode($source);
     }
 
     /**
@@ -547,8 +553,8 @@ class Server
     {
         $path = $this->makeImage($path, $params);
 
-        header('Content-Type:'.$this->cache->getMimetype($path));
-        header('Content-Length:'.$this->cache->getSize($path));
+        header('Content-Type:'.$this->cache->mimeType($path));
+        header('Content-Length:'.$this->cache->fileSize($path));
         header('Cache-Control:'.'max-age=31536000, public');
         header('Expires:'.date_create('+1 years')->format('D, d M Y H:i:s').' GMT');
 
@@ -603,18 +609,14 @@ class Server
         }
 
         try {
-            $write = $this->cache->write(
+            $this->cache->write(
                 $cachedPath,
                 $this->api->run($tmp, $this->getAllParams($params))
             );
-
-            if (false === $write) {
-                throw new FilesystemException('Could not write the image `'.$cachedPath.'`.');
-            }
-        } catch (FileExistsException $exception) {
-            // This edge case occurs when the target already exists
-            // because it's currently be written to disk in another
-            // request. It's best to just fail silently.
+        } catch (FilesystemV2Exception $exception) {
+            throw new FilesystemException(
+                'Could not write the image `'.$cachedPath.'`.'
+            );
         } finally {
             unlink($tmp);
         }

--- a/src/Server.php
+++ b/src/Server.php
@@ -99,9 +99,9 @@ class Server
     /**
      * Create Server instance.
      *
-     * @param FilesystemOperator  $source Source file system.
-     * @param FilesystemOperator  $cache  Cache file system.
-     * @param ApiInterface        $api    Image manipulation API.
+     * @param FilesystemOperator $source Source file system.
+     * @param FilesystemOperator $cache  Cache file system.
+     * @param ApiInterface       $api    Image manipulation API.
      */
     public function __construct(FilesystemOperator $source, FilesystemOperator $cache, ApiInterface $api)
     {
@@ -545,9 +545,7 @@ class Server
 
             return 'data:'.$this->cache->mimeType($path).';base64,'.base64_encode($source);
         } catch (FilesystemV2Exception $exception) {
-            throw new FilesystemException(
-                'Could not read the image `'.$path.'`.'
-            );
+            throw new FilesystemException('Could not read the image `'.$path.'`.');
         }
     }
 
@@ -577,9 +575,7 @@ class Server
             fpassthru($stream);
             fclose($stream);
         } catch (FilesystemV2Exception $exception) {
-            throw new FilesystemException(
-                'Could not read the image `'.$path.'`.'
-            );
+            throw new FilesystemException('Could not read the image `'.$path.'`.');
         }
     }
 
@@ -612,9 +608,7 @@ class Server
                 $sourcePath
             );
         } catch (FilesystemV2Exception $exception) {
-            throw new FilesystemException(
-                'Could not read the image `'.$sourcePath.'`.'
-            );
+            throw new FilesystemException('Could not read the image `'.$sourcePath.'`.');
         }
 
         // We need to write the image to the local disk before
@@ -632,9 +626,7 @@ class Server
                 $this->api->run($tmp, $this->getAllParams($params))
             );
         } catch (FilesystemV2Exception $exception) {
-            throw new FilesystemException(
-                'Could not write the image `'.$cachedPath.'`.'
-            );
+            throw new FilesystemException('Could not write the image `'.$cachedPath.'`.');
         } finally {
             unlink($tmp);
         }

--- a/src/Server.php
+++ b/src/Server.php
@@ -563,18 +563,24 @@ class Server
     {
         $path = $this->makeImage($path, $params);
 
-        header('Content-Type:'.$this->cache->mimeType($path));
-        header('Content-Length:'.$this->cache->fileSize($path));
-        header('Cache-Control:'.'max-age=31536000, public');
-        header('Expires:'.date_create('+1 years')->format('D, d M Y H:i:s').' GMT');
+        try {
+            header('Content-Type:'.$this->cache->mimeType($path));
+            header('Content-Length:'.$this->cache->fileSize($path));
+            header('Cache-Control:'.'max-age=31536000, public');
+            header('Expires:'.date_create('+1 years')->format('D, d M Y H:i:s').' GMT');
 
-        $stream = $this->cache->readStream($path);
+            $stream = $this->cache->readStream($path);
 
-        if (0 !== ftell($stream)) {
-            rewind($stream);
+            if (0 !== ftell($stream)) {
+                rewind($stream);
+            }
+            fpassthru($stream);
+            fclose($stream);
+        } catch (FilesystemV2Exception $exception) {
+            throw new FilesystemException(
+                'Could not read the image `'.$path.'`.'
+            );
         }
-        fpassthru($stream);
-        fclose($stream);
     }
 
     /**

--- a/src/Server.php
+++ b/src/Server.php
@@ -190,7 +190,11 @@ class Server
      */
     public function sourceFileExists($path)
     {
-        return $this->source->fileExists($this->getSourcePath($path));
+        try {
+            return $this->source->fileExists($this->getSourcePath($path));
+        } catch (FilesystemV2Exception $exception) {
+            return false;
+        }
     }
 
     /**
@@ -366,9 +370,13 @@ class Server
      */
     public function cacheFileExists($path, array $params)
     {
-        return $this->cache->fileExists(
-            $this->getCachePath($path, $params)
-        );
+        try {
+            return $this->cache->fileExists(
+                $this->getCachePath($path, $params)
+            );
+        } catch (FilesystemV2Exception $exception) {
+            return false;
+        }
     }
 
     /**
@@ -532,13 +540,15 @@ class Server
     {
         $path = $this->makeImage($path, $params);
 
-        $source = $this->cache->read($path);
+        try {
+            $source = $this->cache->read($path);
 
-        if (false === $source) {
-            throw new FilesystemException('Could not read the image `'.$path.'`.');
+            return 'data:'.$this->cache->mimeType($path).';base64,'.base64_encode($source);
+        } catch (FilesystemV2Exception $exception) {
+            throw new FilesystemException(
+                'Could not read the image `'.$path.'`.'
+            );
         }
-
-        return 'data:'.$this->cache->mimeType($path).';base64,'.base64_encode($source);
     }
 
     /**
@@ -591,12 +601,14 @@ class Server
             throw new FileNotFoundException('Could not find the image `'.$sourcePath.'`.');
         }
 
-        $source = $this->source->read(
-            $sourcePath
-        );
-
-        if (false === $source) {
-            throw new FilesystemException('Could not read the image `'.$sourcePath.'`.');
+        try {
+            $source = $this->source->read(
+                $sourcePath
+            );
+        } catch (FilesystemV2Exception $exception) {
+            throw new FilesystemException(
+                'Could not read the image `'.$sourcePath.'`.'
+            );
         }
 
         // We need to write the image to the local disk before

--- a/src/Server.php
+++ b/src/Server.php
@@ -392,7 +392,7 @@ class Server
             throw new InvalidArgumentException('Deleting cached image manipulations is not possible when grouping cache into folders is disabled.');
         }
 
-        try{
+        try {
             $this->cache->deleteDirectory(
                 dirname($this->getCachePath($path))
             );

--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -4,9 +4,9 @@ namespace League\Glide;
 
 use Intervention\Image\ImageManager;
 use InvalidArgumentException;
-use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
-use League\Flysystem\FilesystemInterface;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 use League\Glide\Api\Api;
 use League\Glide\Manipulators\Background;
 use League\Glide\Manipulators\Blur;
@@ -76,7 +76,7 @@ class ServerFactory
     /**
      * Get source file system.
      *
-     * @return FilesystemInterface Source file system.
+     * @return FilesystemOperator Source file system.
      */
     public function getSource()
     {
@@ -86,7 +86,7 @@ class ServerFactory
 
         if (is_string($this->config['source'])) {
             return new Filesystem(
-                new Local($this->config['source'])
+                new LocalFilesystemAdapter($this->config['source'])
             );
         }
 
@@ -108,7 +108,7 @@ class ServerFactory
     /**
      * Get cache file system.
      *
-     * @return FilesystemInterface Cache file system.
+     * @return FilesystemOperator Cache file system.
      */
     public function getCache()
     {
@@ -118,7 +118,7 @@ class ServerFactory
 
         if (is_string($this->config['cache'])) {
             return new Filesystem(
-                new Local($this->config['cache'])
+                new LocalFilesystemAdapter($this->config['cache'])
             );
         }
 
@@ -180,7 +180,7 @@ class ServerFactory
     /**
      * Get watermarks file system.
      *
-     * @return FilesystemInterface|null Watermarks file system.
+     * @return FilesystemOperator|null Watermarks file system.
      */
     public function getWatermarks()
     {
@@ -190,7 +190,7 @@ class ServerFactory
 
         if (is_string($this->config['watermarks'])) {
             return new Filesystem(
-                new Local($this->config['watermarks'])
+                new LocalFilesystemAdapter($this->config['watermarks'])
             );
         }
 

--- a/tests/Manipulators/WatermarkTest.php
+++ b/tests/Manipulators/WatermarkTest.php
@@ -13,7 +13,7 @@ class WatermarkTest extends TestCase
     public function setUp(): void
     {
         $this->manipulator = new Watermark(
-            Mockery::mock('League\Flysystem\FilesystemInterface')
+            Mockery::mock('League\Flysystem\FilesystemOperator')
         );
     }
 
@@ -29,13 +29,13 @@ class WatermarkTest extends TestCase
 
     public function testSetWatermarks()
     {
-        $this->manipulator->setWatermarks(Mockery::mock('League\Flysystem\FilesystemInterface'));
-        $this->assertInstanceOf('League\Flysystem\FilesystemInterface', $this->manipulator->getWatermarks());
+        $this->manipulator->setWatermarks(Mockery::mock('League\Flysystem\FilesystemOperator'));
+        $this->assertInstanceOf('League\Flysystem\FilesystemOperator', $this->manipulator->getWatermarks());
     }
 
     public function testGetWatermarks()
     {
-        $this->assertInstanceOf('League\Flysystem\FilesystemInterface', $this->manipulator->getWatermarks());
+        $this->assertInstanceOf('League\Flysystem\FilesystemOperator', $this->manipulator->getWatermarks());
     }
 
     public function testSetWatermarksPathPrefix()
@@ -61,8 +61,8 @@ class WatermarkTest extends TestCase
             }))->once();
         });
 
-        $this->manipulator->setWatermarks(Mockery::mock('League\Flysystem\FilesystemInterface', function ($watermarks) {
-            $watermarks->shouldReceive('has')->with('image.jpg')->andReturn(true)->once();
+        $this->manipulator->setWatermarks(Mockery::mock('League\Flysystem\FilesystemOperator', function ($watermarks) {
+            $watermarks->shouldReceive('fileExists')->with('image.jpg')->andReturn(true)->once();
             $watermarks->shouldReceive('read')->with('image.jpg')->andReturn('content')->once();
         }));
 
@@ -85,7 +85,7 @@ class WatermarkTest extends TestCase
     public function testGetImage()
     {
         $this->manipulator->getWatermarks()
-            ->shouldReceive('has')
+            ->shouldReceive('fileExists')
                 ->with('watermarks/image.jpg')
                 ->andReturn(true)
                 ->once()
@@ -116,13 +116,13 @@ class WatermarkTest extends TestCase
         $this->expectExceptionMessage('Could not read the image `image.jpg`.');
 
         $this->manipulator->getWatermarks()
-            ->shouldReceive('has')
+            ->shouldReceive('fileExists')
                 ->with('image.jpg')
                 ->andReturn(true)
                 ->once()
             ->shouldReceive('read')
                 ->with('image.jpg')
-                ->andReturn(false)
+                ->andThrow('League\Flysystem\UnableToReadFile')
                 ->once();
 
         $image = Mockery::mock('Intervention\Image\Image');

--- a/tests/Responses/PsrResponseFactoryTest.php
+++ b/tests/Responses/PsrResponseFactoryTest.php
@@ -30,9 +30,9 @@ class PsrResponseFactoryTest extends TestCase
             return $stream;
         };
 
-        $cache = Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('getMimetype')->andReturn('image/jpeg');
-            $mock->shouldReceive('getSize')->andReturn(0);
+        $cache = Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('mimeType')->andReturn('image/jpeg');
+            $mock->shouldReceive('fileSize')->andReturn(0);
             $mock->shouldReceive('readStream')->andReturn(
                 Mockery::mock('Psr\Http\Message\StreamInterface')
             );

--- a/tests/ServerFactoryTest.php
+++ b/tests/ServerFactoryTest.php
@@ -16,8 +16,8 @@ class ServerFactoryTest extends TestCase
     public function testGetServer()
     {
         $server = new ServerFactory([
-            'source' => Mockery::mock('League\Flysystem\FilesystemInterface'),
-            'cache' => Mockery::mock('League\Flysystem\FilesystemInterface'),
+            'source' => Mockery::mock('League\Flysystem\FilesystemOperator'),
+            'cache' => Mockery::mock('League\Flysystem\FilesystemOperator'),
             'response' => Mockery::mock('League\Glide\Responses\ResponseFactoryInterface'),
         ]);
 
@@ -27,16 +27,16 @@ class ServerFactoryTest extends TestCase
     public function testGetSource()
     {
         $server = new ServerFactory([
-            'source' => Mockery::mock('League\Flysystem\FilesystemInterface'),
+            'source' => Mockery::mock('League\Flysystem\FilesystemOperator'),
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\FilesystemInterface', $server->getSource());
+        $this->assertInstanceOf('League\Flysystem\FilesystemOperator', $server->getSource());
 
         $server = new ServerFactory([
             'source' => sys_get_temp_dir(),
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\FilesystemInterface', $server->getSource());
+        $this->assertInstanceOf('League\Flysystem\FilesystemOperator', $server->getSource());
     }
 
     public function testGetSourceWithNoneSet()
@@ -60,16 +60,16 @@ class ServerFactoryTest extends TestCase
     public function testGetCache()
     {
         $server = new ServerFactory([
-            'cache' => Mockery::mock('League\Flysystem\FilesystemInterface'),
+            'cache' => Mockery::mock('League\Flysystem\FilesystemOperator'),
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\FilesystemInterface', $server->getCache());
+        $this->assertInstanceOf('League\Flysystem\FilesystemOperator', $server->getCache());
 
         $server = new ServerFactory([
             'cache' => sys_get_temp_dir(),
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\FilesystemInterface', $server->getCache());
+        $this->assertInstanceOf('League\Flysystem\FilesystemOperator', $server->getCache());
     }
 
     public function testGetCacheWithNoneSet()
@@ -128,16 +128,16 @@ class ServerFactoryTest extends TestCase
     public function testGetWatermarks()
     {
         $server = new ServerFactory([
-            'watermarks' => Mockery::mock('League\Flysystem\FilesystemInterface'),
+            'watermarks' => Mockery::mock('League\Flysystem\FilesystemOperator'),
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\FilesystemInterface', $server->getWatermarks());
+        $this->assertInstanceOf('League\Flysystem\FilesystemOperator', $server->getWatermarks());
 
         $server = new ServerFactory([
             'watermarks' => sys_get_temp_dir(),
         ]);
 
-        $this->assertInstanceOf('League\Flysystem\FilesystemInterface', $server->getWatermarks());
+        $this->assertInstanceOf('League\Flysystem\FilesystemOperator', $server->getWatermarks());
     }
 
     public function testGetWatermarksPathPrefix()
@@ -250,8 +250,8 @@ class ServerFactoryTest extends TestCase
     public function testCreate()
     {
         $server = ServerFactory::create([
-            'source' => Mockery::mock('League\Flysystem\FilesystemInterface'),
-            'cache' => Mockery::mock('League\Flysystem\FilesystemInterface'),
+            'source' => Mockery::mock('League\Flysystem\FilesystemOperator'),
+            'cache' => Mockery::mock('League\Flysystem\FilesystemOperator'),
             'response' => Mockery::mock('League\Glide\Responses\ResponseFactoryInterface'),
             'temp_dir' => __DIR__,
         ]);

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -569,26 +569,4 @@ class ServerTest extends TestCase
 
         $this->server->makeImage('image.jpg', []);
     }
-
-    public function testMakeImageWithExistingCacheFile()
-    {
-        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
-            $mock->shouldReceive('fileExists')->andReturn(true)->once();
-            $mock->shouldReceive('read')->andReturn('content')->once();
-        }));
-
-        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
-            $mock->shouldReceive('fileExists')->andReturn(false)->once();
-            $mock->shouldReceive('write')->andThrow(new \League\Flysystem\FileExistsException('75094881e9fd2b93063d6a5cb083091c'));
-        }));
-
-        $this->server->setApi(Mockery::mock('League\Glide\Api\ApiInterface', function ($mock) {
-            $mock->shouldReceive('run')->andReturn('content')->once();
-        }));
-
-        $this->assertEquals(
-            'image.jpg/75094881e9fd2b93063d6a5cb083091c',
-            $this->server->makeImage('image.jpg', [])
-        );
-    }
 }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -27,8 +27,8 @@ class ServerTest extends TestCase
             });
 
         $this->server = new Server(
-            Mockery::mock('League\Flysystem\FilesystemInterface'),
-            Mockery::mock('League\Flysystem\FilesystemInterface'),
+            Mockery::mock('League\Flysystem\FilesystemOperator'),
+            Mockery::mock('League\Flysystem\FilesystemOperator'),
             Mockery::mock('League\Glide\Api\ApiInterface'),
             $responseFactory
         );
@@ -46,13 +46,13 @@ class ServerTest extends TestCase
 
     public function testSetSource()
     {
-        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemInterface'));
-        $this->assertInstanceOf('League\Flysystem\FilesystemInterface', $this->server->getSource());
+        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemOperator'));
+        $this->assertInstanceOf('League\Flysystem\FilesystemOperator', $this->server->getSource());
     }
 
     public function testGetSource()
     {
-        $this->assertInstanceOf('League\Flysystem\FilesystemInterface', $this->server->getSource());
+        $this->assertInstanceOf('League\Flysystem\FilesystemOperator', $this->server->getSource());
     }
 
     public function testSetSourcePathPrefix()
@@ -102,8 +102,8 @@ class ServerTest extends TestCase
 
     public function testSourceFileExists()
     {
-        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->with('image.jpg')->andReturn(true)->once();
+        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->with('image.jpg')->andReturn(true)->once();
         }));
 
         $this->assertTrue($this->server->sourceFileExists('image.jpg'));
@@ -122,13 +122,13 @@ class ServerTest extends TestCase
 
     public function testSetCache()
     {
-        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemInterface'));
-        $this->assertInstanceOf('League\Flysystem\FilesystemInterface', $this->server->getCache());
+        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemOperator'));
+        $this->assertInstanceOf('League\Flysystem\FilesystemOperator', $this->server->getCache());
     }
 
     public function testGetCache()
     {
-        $this->assertInstanceOf('League\Flysystem\FilesystemInterface', $this->server->getCache());
+        $this->assertInstanceOf('League\Flysystem\FilesystemOperator', $this->server->getCache());
     }
 
     public function testSetCachePathPrefix()
@@ -264,8 +264,8 @@ class ServerTest extends TestCase
 
     public function testCacheFileExists()
     {
-        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->with('image.jpg/75094881e9fd2b93063d6a5cb083091c')->andReturn(true)->once();
+        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->with('image.jpg/75094881e9fd2b93063d6a5cb083091c')->andReturn(true)->once();
         }));
 
         $this->assertTrue($this->server->cacheFileExists('image.jpg', []));
@@ -273,8 +273,8 @@ class ServerTest extends TestCase
 
     public function testDeleteCache()
     {
-        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('deleteDir')->with('image.jpg')->andReturn(true)->once();
+        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('deleteDirectory')->with('image.jpg')->andReturn(true)->once();
         }));
 
         $this->assertTrue($this->server->deleteCache('image.jpg', []));
@@ -387,8 +387,8 @@ class ServerTest extends TestCase
             $mock->shouldReceive('create')->andReturn(Mockery::mock('Psr\Http\Message\ResponseInterface'));
         }));
 
-        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->andReturn(true);
+        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->andReturn(true);
         }));
 
         $this->assertInstanceOf(
@@ -407,9 +407,9 @@ class ServerTest extends TestCase
 
     public function testGetImageAsBase64()
     {
-        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->andReturn(true);
-            $mock->shouldReceive('getMimetype')->andReturn('image/jpeg');
+        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->andReturn(true);
+            $mock->shouldReceive('mimeType')->andReturn('image/jpeg');
             $mock->shouldReceive('read')->andReturn('content')->once();
         }));
 
@@ -424,9 +424,10 @@ class ServerTest extends TestCase
         $this->expectException(FilesystemException::class);
         $this->expectExceptionMessage('Could not read the image `image.jpg/75094881e9fd2b93063d6a5cb083091c`.');
 
-        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->andReturn(true);
-            $mock->shouldReceive('read')->andReturn(false)->once();
+        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->andReturn(true);
+            $mock->shouldReceive('mimeType')->andReturn('image/jpeg');
+            $mock->shouldReceive('read')->andThrow('League\Flysystem\UnableToReadFile')->once();
         }));
 
         $this->server->getImageAsBase64('image.jpg', []);
@@ -437,10 +438,10 @@ class ServerTest extends TestCase
      */
     public function testOutputImage()
     {
-        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->andReturn(true);
-            $mock->shouldReceive('getMimetype')->andReturn('image/jpeg');
-            $mock->shouldReceive('getSize')->andReturn(0);
+        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->andReturn(true);
+            $mock->shouldReceive('mimeType')->andReturn('image/jpeg');
+            $mock->shouldReceive('fileSize')->andReturn(0);
 
             $file = tmpfile();
             fwrite($file, 'content');
@@ -457,13 +458,13 @@ class ServerTest extends TestCase
 
     public function testMakeImageFromSource()
     {
-        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->andReturn(true)->once();
+        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->andReturn(true)->once();
             $mock->shouldReceive('read')->andReturn('content')->once();
         }));
 
-        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->andReturn(false)->once();
+        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->andReturn(false)->once();
             $mock->shouldReceive('write')->with('image.jpg/75094881e9fd2b93063d6a5cb083091c', 'content')->once();
         }));
 
@@ -504,8 +505,8 @@ class ServerTest extends TestCase
 
     public function testMakeImageFromCache()
     {
-        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->andReturn(true);
+        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->andReturn(true);
         }));
 
         $this->assertEquals(
@@ -519,12 +520,12 @@ class ServerTest extends TestCase
         $this->expectException(FileNotFoundException::class);
         $this->expectExceptionMessage('Could not find the image `image.jpg`.');
 
-        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->andReturn(false)->once();
+        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->andReturn(false)->once();
         }));
 
-        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->andReturn(false)->once();
+        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->andReturn(false)->once();
         }));
 
         $this->server->makeImage('image.jpg', []);
@@ -535,13 +536,13 @@ class ServerTest extends TestCase
         $this->expectException(FilesystemException::class);
         $this->expectExceptionMessage('Could not read the image `image.jpg`.');
 
-        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->andReturn(true)->once();
-            $mock->shouldReceive('read')->andReturn(false)->once();
+        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->andReturn(true)->once();
+            $mock->shouldReceive('read')->andThrow('League\Flysystem\UnableToReadFile')->once();
         }));
 
-        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->andReturn(false)->once();
+        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->andThrow('League\Flysystem\UnableToCheckFileExistence')->once();
         }));
 
         $this->server->makeImage('image.jpg', []);
@@ -552,14 +553,14 @@ class ServerTest extends TestCase
         $this->expectException(FilesystemException::class);
         $this->expectExceptionMessage('Could not write the image `image.jpg/75094881e9fd2b93063d6a5cb083091c`.');
 
-        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->andReturn(true)->once();
+        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->andReturn(true)->once();
             $mock->shouldReceive('read')->andReturn('content')->once();
         }));
 
-        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->andReturn(false)->once();
-            $mock->shouldReceive('write')->andReturn(false)->once();
+        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->andThrow('League\Flysystem\UnableToCheckFileExistence')->once();
+            $mock->shouldReceive('write')->andThrow('League\Flysystem\UnableToWriteFile')->once();
         }));
 
         $this->server->setApi(Mockery::mock('League\Glide\Api\ApiInterface', function ($mock) {
@@ -571,13 +572,13 @@ class ServerTest extends TestCase
 
     public function testMakeImageWithExistingCacheFile()
     {
-        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->andReturn(true)->once();
+        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->andReturn(true)->once();
             $mock->shouldReceive('read')->andReturn('content')->once();
         }));
 
-        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->andReturn(false)->once();
+        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->andReturn(false)->once();
             $mock->shouldReceive('write')->andThrow(new \League\Flysystem\FileExistsException('75094881e9fd2b93063d6a5cb083091c'));
         }));
 

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -481,13 +481,13 @@ class ServerTest extends TestCase
 
     public function testMakeImageFromSourceWithCustomTmpDir()
     {
-        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->andReturn(true)->once();
+        $this->server->setSource(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->andReturn(true)->once();
             $mock->shouldReceive('read')->andReturn('content')->once();
         }));
 
-        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemInterface', function ($mock) {
-            $mock->shouldReceive('has')->andReturn(false)->once();
+        $this->server->setCache(Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+            $mock->shouldReceive('fileExists')->andReturn(false)->once();
             $mock->shouldReceive('write')->with('image.jpg/75094881e9fd2b93063d6a5cb083091c', 'content')->once();
         }));
 


### PR DESCRIPTION
This PR contains changes that remove Flysystem 1 and adapt to Flysystem 2.

Most of the work went into changing test suite to mimic Flysystem 2 exception logic, while changes to the code are rather simple.

I create another PR to visualize changes needed to migrate fully from V1 to V2 in case this will be the way chosen by maintainers.