### PR TITLE
Allow to configure temp directory

### DIFF
--- a/docs/1.0/config/advanced-usage.md
+++ b/docs/1.0/config/advanced-usage.md
@@ -62,6 +62,12 @@ public function getCachePath($path, array $params)
 
 // Check if a cache file exists
 public function cacheFileExists($path, array $params)
+
+// Set the temporary directory that should be used to store EXIF data
+public function setTempDir($tempDir)
+
+// Get the current temporary directory
+public function getTempDir()
 ~~~
 
 ## Api

--- a/docs/1.0/config/setup.md
+++ b/docs/1.0/config/setup.md
@@ -19,6 +19,8 @@ $server = League\Glide\ServerFactory::create([
     'source_path_prefix' =>      // Source filesystem path prefix
     'cache' =>                   // Cache filesystem
     'cache_path_prefix' =>       // Cache filesystem path prefix
+    'temp_dir' =>                // Temporary directory where cache EXIF data should be stored 
+                                 // (defaults to sys_get_temp_dir())
     'group_cache_in_folders' =>  // Whether to group cached images in folders
     'watermarks' =>              // Watermarks filesystem
     'watermarks_path_prefix' =>  // Watermarks filesystem path prefix

--- a/src/Server.php
+++ b/src/Server.php
@@ -41,6 +41,13 @@ class Server
     protected $cachePathPrefix;
 
     /**
+     * Temporary EXIF data directory.
+     *
+     * @var string
+     */
+    protected $tempDir;
+
+    /**
      * Whether to group cache in folders.
      *
      * @var bool
@@ -101,6 +108,7 @@ class Server
         $this->setSource($source);
         $this->setCache($cache);
         $this->setApi($api);
+        $this->tempDir = sys_get_temp_dir();
     }
 
     /**
@@ -243,6 +251,32 @@ class Server
     public function getCachePathPrefix()
     {
         return $this->cachePathPrefix;
+    }
+
+    /**
+     * Get temporary EXIF data directory.
+     *
+     * @return string
+     */
+    public function getTempDir()
+    {
+        return $this->tempDir;
+    }
+
+    /**
+     * Set temporary EXIF data directory. This directory must be a local path and exists on the filesystem.
+     *
+     * @param string $path
+     *
+     * @throws InvalidArgumentException
+     */
+    public function setTempDir($tempDir)
+    {
+        if (!$tempDir || !is_dir($tempDir)) {
+            throw new InvalidArgumentException(sprintf('Invalid temp dir provided: "%s" does not exist.', $tempDir));
+        }
+
+        $this->tempDir = rtrim($tempDir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
     }
 
     /**
@@ -562,7 +596,7 @@ class Server
         // We need to write the image to the local disk before
         // doing any manipulations. This is because EXIF data
         // can only be read from an actual file.
-        $tmp = tempnam(sys_get_temp_dir(), 'Glide');
+        $tmp = tempnam($this->tempDir, 'Glide');
 
         if (false === file_put_contents($tmp, $source)) {
             throw new FilesystemException('Unable to write temp file for `'.$sourcePath.'`.');

--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -66,6 +66,10 @@ class ServerFactory
         $server->setBaseUrl($this->getBaseUrl());
         $server->setResponseFactory($this->getResponseFactory());
 
+        if ($this->getTempDir()) {
+            $server->setTempDir($this->getTempDir());
+        }
+
         return $server;
     }
 
@@ -130,6 +134,18 @@ class ServerFactory
     {
         if (isset($this->config['cache_path_prefix'])) {
             return $this->config['cache_path_prefix'];
+        }
+    }
+
+    /**
+     * Get temporary EXIF data directory.
+     *
+     * @return string
+     */
+    public function getTempDir()
+    {
+        if (isset($this->config['temp_dir'])) {
+            return $this->config['temp_dir'];
         }
     }
 

--- a/tests/ServerFactoryTest.php
+++ b/tests/ServerFactoryTest.php
@@ -5,7 +5,6 @@ namespace League\Glide;
 use InvalidArgumentException;
 use Mockery;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\TextUI\XmlConfiguration\Directory;
 
 class ServerFactoryTest extends TestCase
 {

--- a/tests/ServerFactoryTest.php
+++ b/tests/ServerFactoryTest.php
@@ -5,6 +5,7 @@ namespace League\Glide;
 use InvalidArgumentException;
 use Mockery;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\TextUI\XmlConfiguration\Directory;
 
 class ServerFactoryTest extends TestCase
 {
@@ -88,6 +89,15 @@ class ServerFactoryTest extends TestCase
         ]);
 
         $this->assertSame('cache', $server->getCachePathPrefix());
+    }
+
+    public function testGetTempDir()
+    {
+        $server = new ServerFactory([
+            'temp_dir' => __DIR__,
+        ]);
+
+        $this->assertSame(__DIR__, $server->getTempDir());
     }
 
     public function testGetGroupCacheInFolders()
@@ -244,8 +254,10 @@ class ServerFactoryTest extends TestCase
             'source' => Mockery::mock('League\Flysystem\FilesystemInterface'),
             'cache' => Mockery::mock('League\Flysystem\FilesystemInterface'),
             'response' => Mockery::mock('League\Glide\Responses\ResponseFactoryInterface'),
+            'temp_dir' => __DIR__,
         ]);
 
         $this->assertInstanceOf('League\Glide\Server', $server);
+        $this->assertSame(__DIR__.DIRECTORY_SEPARATOR, $server->getTempDir());
     }
 }


### PR DESCRIPTION
Introduce the ability to configure the temporary directory used to store EXIF data. It's an adaptation of @jaapio work in https://github.com/thephpleague/glide/pull/165, thanks for the PR!

Replace https://github.com/thephpleague/glide/pull/165
Fixes https://github.com/thephpleague/glide/issues/156
Fixes https://github.com/thephpleague/glide/issues/186