### PR TITLE
Fix rounding issue with Manipulators\Size

### DIFF
--- a/src/Manipulators/Size.php
+++ b/src/Manipulators/Size.php
@@ -162,12 +162,14 @@ class Size extends BaseManipulator
             $height = $image->height();
         }
 
-        if (is_null($width)) {
-            $width = $height * ($image->width() / $image->height());
-        }
+        if (is_null($width) || is_null($height)) {
+            $size = (new \Intervention\Image\Size($image->width(), $image->height()))
+              ->resize($width, $height, function ($constraint) {
+                  $constraint->aspectRatio();
+              });
 
-        if (is_null($height)) {
-            $height = $width / ($image->width() / $image->height());
+            $width = $size->getWidth();
+            $height = $size->getHeight();
         }
 
         return [

--- a/tests/Manipulators/SizeTest.php
+++ b/tests/Manipulators/SizeTest.php
@@ -126,6 +126,16 @@ class SizeTest extends TestCase
         $this->assertSame([200, 100], $this->manipulator->resolveMissingDimensions($image, null, 100));
     }
 
+    public function testResolveMissingDimensionsWithOddDimensions()
+    {
+        $image = Mockery::mock('Intervention\Image\Image', function ($mock) {
+            $mock->shouldReceive('width')->andReturn(1024);
+            $mock->shouldReceive('height')->andReturn(553);
+        });
+
+        $this->assertSame([411, 222], $this->manipulator->resolveMissingDimensions($image, 411, null));
+    }
+
     public function testLimitImageSize()
     {
         $this->assertSame([1000, 1000], $this->manipulator->limitImageSize(1000, 1000));


### PR DESCRIPTION
If I have an image with a size of 1024x553 pixel and I run

```php
(new \League\Glide\Manipulators\Size)
    ->setParams(['w' => 411, 'fit' => 'max'])
    ->run($image);
```

on it. I will get an image with the dimensions 409x221 pixel.

It looks like this happens due to the calculations in \League\Glide\Manipulators\Size::resolveMissingDimensions(). For the example above it will keep the width of 411 px and calculate a height of 221 px. Intervention Image rounds numbers differently, resulting in this wrong image size when the image is actually resized to the precalculated size.

To fix this issue I would suggest to rely on the resizing logic of Intervention Image.