### PR TITLE
Enable TIFF image format handling, fixes #344

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: '7.4'
-                  extensions: gd imagick
+                  extensions: gd, imagick
             - name: php-cs-fixer
               run: |
                   wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.16.4/php-cs-fixer.phar -q

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: '7.4'
-                  extensions: gd
+                  extensions: gd imagick
             - name: php-cs-fixer
               run: |
                   wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.16.4/php-cs-fixer.phar -q

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php-version }}
-                  extensions: gd
+                  extensions: gd, imagick
                   coverage: pcov
 
             - name: Composer
@@ -66,7 +66,7 @@ jobs:
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: '7.4'
-                  extensions: gd
+                  extensions: gd, imagick
                   tools: vimeo/psalm:4.15
             - name: psalm
               run: |

--- a/src/Manipulators/Encode.php
+++ b/src/Manipulators/Encode.php
@@ -52,6 +52,7 @@ class Encode extends BaseManipulator
             'pjpg' => 'image/jpeg',
             'png' => 'image/png',
             'webp' => 'image/webp',
+            'tiff' => 'image/tiff',
         ];
 
         if (array_key_exists($this->fm, $allowed)) {

--- a/tests/Manipulators/EncodeTest.php
+++ b/tests/Manipulators/EncodeTest.php
@@ -132,4 +132,28 @@ class EncodeTest extends TestCase
         $this->assertSame(90, $this->manipulator->setParams(['q' => '-1'])->getQuality());
         $this->assertSame(90, $this->manipulator->setParams(['q' => '101'])->getQuality());
     }
+
+    /**
+     * Test functions that require the imagick extension.
+     *
+     * @return void
+     */
+    public function testWithImagick()
+    {
+        if (!extension_loaded('imagick')) {
+            $this->markTestSkipped(
+                'The imagick extension is not available.'
+            );
+        }
+        $manager = new ImageManager(['driver' => 'imagick']);
+        //These need to be recreated with the imagick driver selected in the manager
+        $this->jpg = $manager->canvas(100, 100)->encode('jpg');
+        $this->png = $manager->canvas(100, 100)->encode('png');
+        $this->gif = $manager->canvas(100, 100)->encode('gif');
+        $this->tif = $manager->canvas(100, 100)->encode('tiff');
+
+        $this->assertSame('image/tiff', $this->manipulator->setParams(['fm' => 'tiff'])->run($this->jpg)->mime);
+        $this->assertSame('image/tiff', $this->manipulator->setParams(['fm' => 'tiff'])->run($this->png)->mime);
+        $this->assertSame('image/tiff', $this->manipulator->setParams(['fm' => 'tiff'])->run($this->gif)->mime);
+    }
 }


### PR DESCRIPTION
Further to #344, here's a PR to enable TIFF image format support. I saw that there were some vestiges of TIFF format support already (for example the `tif` property in the test case), so I've made use of that. The test suite runs only with the `gd` driver, so operations that require `imagick` (which includes the TIFF format) can't be tested, so I wrote a new test method that reconfigures the test to run with imagick, and skips the test if it's not installed.

I don't understand how the mock works in `testGetFormat` – I tried copying it but couldn't make it work, so I've not created a similar test for that.