### PR TITLE
Break out the list of supported image formats

### DIFF
--- a/src/Manipulators/Encode.php
+++ b/src/Manipulators/Encode.php
@@ -65,10 +65,10 @@ class Encode extends BaseManipulator
     {
         return [
             'avif' => 'image/avif',
-            'gif'  => 'image/gif',
-            'jpg'  => 'image/jpeg',
+            'gif' => 'image/gif',
+            'jpg' => 'image/jpeg',
             'pjpg' => 'image/jpeg',
-            'png'  => 'image/png',
+            'png' => 'image/png',
             'webp' => 'image/webp',
             'tiff' => 'image/tiff',
         ];

--- a/src/Manipulators/Encode.php
+++ b/src/Manipulators/Encode.php
@@ -45,25 +45,33 @@ class Encode extends BaseManipulator
      */
     public function getFormat(Image $image)
     {
-        $allowed = [
-            'avif' => 'image/avif',
-            'gif' => 'image/gif',
-            'jpg' => 'image/jpeg',
-            'pjpg' => 'image/jpeg',
-            'png' => 'image/png',
-            'webp' => 'image/webp',
-            'tiff' => 'image/tiff',
-        ];
-
-        if (array_key_exists($this->fm, $allowed)) {
+        if (array_key_exists($this->fm, static::allowedFormats())) {
             return $this->fm;
         }
 
-        if ($format = array_search($image->mime(), $allowed, true)) {
+        if ($format = array_search($image->mime(), static::allowedFormats(), true)) {
             return $format;
         }
 
         return 'jpg';
+    }
+
+    /**
+     * Get a list of supported image formats and MIME types.
+     *
+     * @return array<string,string>
+     */
+    public static function allowedFormats()
+    {
+        return [
+            'avif' => 'image/avif',
+            'gif'  => 'image/gif',
+            'jpg'  => 'image/jpeg',
+            'pjpg' => 'image/jpeg',
+            'png'  => 'image/png',
+            'webp' => 'image/webp',
+            'tiff' => 'image/tiff',
+        ];
     }
 
     /**


### PR DESCRIPTION
...so that it's visible from outside. As far as I can see there is no public way to obtain a list of the image formats that glide supports (other than docs), so I've moved it to a static method in the Encode Manipulator, and I use that from its own methods too. It's static so it can be overridden easily if someone wants to add (or remove) a format.

This is just an idea – I found that I wanted to find this out when using glide from spatie/image, as otherwise it has to maintain its own list of supported formats, which isn't very DRY.