### PR TITLE
Docs: Adjust default position of markpos

### DIFF
--- a/docs/2.0/api/watermarks.md
+++ b/docs/2.0/api/watermarks.md
@@ -86,7 +86,7 @@ Sets how far the watermark is away from edges of the image. Basically a shortcut
 
 ## Position `markpos`
 
-Sets where the watermark is positioned. Accepts `top-left`, `top`, `top-right`, `left`, `center`, `right`, `bottom-left`, `bottom`, `bottom-right`. Default is `center`.
+Sets where the watermark is positioned. Accepts `top-left`, `top`, `top-right`, `left`, `center`, `right`, `bottom-left`, `bottom`, `bottom-right`. Default is `bottom-right`.
 
 ~~~ html
 <img src="kayaks.jpg?mark=logo.png&markpos=top-left">


### PR DESCRIPTION
The default as per the code is `bottom-right`:

https://github.com/thephpleague/glide/blob/bff5b0fe2fd26b2fde2d6958715fde313887d79d/src/Manipulators/Watermark.php#L257