### PR TITLE
Updates the docs regarding quality parameter

### DIFF
--- a/docs/2.0/api/encode.md
+++ b/docs/2.0/api/encode.md
@@ -7,7 +7,7 @@ title: Encode
 
 ## Quality `q`
 
-Defines the quality of the image. Use values between `0` and `100`. Defaults to `90`. Only relevant if the format is set to `jpg` or `pjpg`.
+Defines the quality of the image. Use values between `0` and `100`. Defaults to `90`. Only relevant if the format is set to `jpg`, `pjpg`, `webp` or `avif`.
 
 ~~~ html
 <img src="kayaks.jpg?w=500&q=25">


### PR DESCRIPTION
The docs state that they quality parameter only applies to `jpg` and `pjpg`, this isn't the case it also applies to `wepb` and `avif`