### PR TITLE
[Docs]: Remove signature params for Laravel integration

### DIFF
--- a/docs/2.0/config/integrations/laravel.md
+++ b/docs/2.0/config/integrations/laravel.md
@@ -61,7 +61,7 @@ class ImageController extends Controller
             'base_url' => 'img',
         ]);
 
-        return $server->getImageResponse($path, request()->all());
+        return $server->getImageResponse($path, request()->except(['expires', 'signature']));
     }
 }
 ~~~


### PR DESCRIPTION
Hey,

I know that the example code doesn't show any usage combined with signed routes (maybe that's worth an example, too?), but since it's not a big change, I think it might make sense to remove the signature params from the request in the example.

I used that code, made the route signed later on and DoS my server with cache images 😅 Just want to prevent others from making the same mistake.

Cheers,
Dennis