### PR TITLE
3.x-fix-quality

### DIFF
--- a/src/Manipulators/Encode.php
+++ b/src/Manipulators/Encode.php
@@ -31,7 +31,7 @@ class Encode extends BaseManipulator
         }
 
         $image = (new ImageManager($driver))->read(
-            $image->encodeByExtension($format, $quality)->toString()
+            $image->encodeByExtension($format, quality: $quality)->toString()
         );
 
         if ($interlace) {


### PR DESCRIPTION
Intervention 3 requires quality to be passed as a named argument; see: https://image.intervention.io/v3/basics/image-output#encode-images-by-file-extension