### PR TITLE
Exception message is hidden

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -689,7 +689,7 @@ class Server
                 $this->api->run($tmp, $this->getAllParams($params))
             );
         } catch (FilesystemV2Exception $exception) {
-            throw new FilesystemException('Could not write the image `'.$cachedPath.'`. ' . $exception->getMessage());
+            throw new FilesystemException('Could not write the image `'.$cachedPath.'`.', 0, $exception);
         } finally {
             unlink($tmp);
         }

--- a/src/Server.php
+++ b/src/Server.php
@@ -689,7 +689,7 @@ class Server
                 $this->api->run($tmp, $this->getAllParams($params))
             );
         } catch (FilesystemV2Exception $exception) {
-            throw new FilesystemException('Could not write the image `'.$cachedPath.'`.');
+            throw new FilesystemException('Could not write the image `'.$cachedPath.'`. ' . $exception->getMessage());
         } finally {
             unlink($tmp);
         }


### PR DESCRIPTION
It took too long to find a cause of a not working cache setup. The real issue was wrong bucket setup:
```
Unable to write file at location: a. {
  "error": {
    "code": 400,
    "message": "Cannot insert legacy ACL for an object when uniform bucket-level access is enabled. Read more at https://cloud.google.com/storage/docs/uniform-bucket-level-access",
    "errors": [
      {
        "message": "Cannot insert legacy ACL for an object when uniform bucket-level access is enabled. Read more at https://cloud.google.com/storage/docs/uniform-bucket-level-access",
        "domain": "global",
        "reason": "invalid"
      }
    ]
  }
}.
```

So exceptions should not be hidden as they do help to solve the problem easier.