### PR TITLE
Optimize ImageInterface instance creation.

### DIFF
--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -2,6 +2,7 @@
 
 namespace League\Glide\Api;
 
+use Intervention\Image\Decoders\BinaryImageDecoder;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Interfaces\ImageInterface;
 use League\Glide\Manipulators\ManipulatorInterface;
@@ -88,7 +89,7 @@ class Api implements ApiInterface
      */
     public function run(string $source, array $params): string
     {
-        $image = $this->imageManager->read($source);
+        $image = $this->imageManager->read($source, BinaryImageDecoder::class);
 
         foreach ($this->manipulators as $manipulator) {
             $manipulator->setParams($params);

--- a/src/Server.php
+++ b/src/Server.php
@@ -620,24 +620,13 @@ class Server
             throw new FilesystemException('Could not read the image `'.$sourcePath.'`.');
         }
 
-        // We need to write the image to the local disk before
-        // doing any manipulations. This is because EXIF data
-        // can only be read from an actual file.
-        $tmp = tempnam($this->tempDir, 'Glide');
-
-        if (false === file_put_contents($tmp, $source)) {
-            throw new FilesystemException('Unable to write temp file for `'.$sourcePath.'`.');
-        }
-
         try {
             $this->cache->write(
                 $cachedPath,
-                $this->api->run($tmp, $this->getAllParams($params))
+                $this->api->run($source, $this->getAllParams($params))
             );
         } catch (FilesystemV2Exception $exception) {
             throw new FilesystemException('Could not write the image `'.$cachedPath.'`.');
-        } finally {
-            unlink($tmp);
         }
 
         return $cachedPath;

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -79,6 +79,9 @@ class ApiTest extends TestCase
 
         $api = new Api($manager, [$manipulator]);
 
-        $this->assertEquals('encoded', $api->run(dirname(__FILE__, 2).'/files/red-pixel.png', []));
+        $this->assertEquals('encoded', $api->run(
+            file_get_contents(dirname(__FILE__, 2).'/files/red-pixel.png'),
+            []
+        ));
     }
 }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -2,7 +2,6 @@
 
 namespace League\Glide;
 
-use Hamcrest\Matchers;
 use League\Glide\Filesystem\FileNotFoundException;
 use League\Glide\Filesystem\FilesystemException;
 use PHPUnit\Framework\TestCase;
@@ -522,8 +521,7 @@ class ServerTest extends TestCase
         }));
 
         $this->server->setApi(\Mockery::mock('League\Glide\Api\ApiInterface', function ($mock) {
-            $tmpDirPattern = Matchers::matchesPattern('~\/?'.sys_get_temp_dir().'.*~');
-            $mock->shouldReceive('run')->withArgs([$tmpDirPattern, []])->andReturn('content')->once();
+            $mock->shouldReceive('run')->withArgs(['content', []])->andReturn('content')->once();
         }));
 
         $this->assertEquals(
@@ -546,8 +544,7 @@ class ServerTest extends TestCase
 
         $this->server->setTempDir(__DIR__);
         $this->server->setApi(\Mockery::mock('League\Glide\Api\ApiInterface', function ($mock) {
-            $tmpDirPattern = Matchers::matchesPattern('~^'.__DIR__.'.*~');
-            $mock->shouldReceive('run')->with($tmpDirPattern, [])->andReturn('content')->once();
+            $mock->shouldReceive('run')->with('content', [])->andReturn('content')->once();
         }));
 
         $this->assertEquals(


### PR DESCRIPTION
- Remove unneeded temp image creation
- Specify only the required binary image decoder class for ImageManager::read()