### PR TITLE
add missing throws annotation

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -374,6 +374,8 @@ class Server
      * @param array  $params Image manipulation params.
      *
      * @return string Cache path.
+     *
+     * @throws FileNotFoundException
      */
     public function getCachePath($path, array $params = [])
     {
@@ -575,6 +577,8 @@ class Server
      * @return mixed Image response.
      *
      * @throws InvalidArgumentException
+     * @throws FileNotFoundException
+     * @throws FilesystemException
      */
     public function getImageResponse($path, array $params)
     {
@@ -595,6 +599,7 @@ class Server
      *
      * @return string Base64 encoded image.
      *
+     * @throws FileNotFoundException
      * @throws FilesystemException
      */
     public function getImageAsBase64($path, array $params)
@@ -617,6 +622,8 @@ class Server
      * @param array  $params Image manipulation params.
      *
      * @throws InvalidArgumentException
+     * @throws FileNotFoundException
+     * @throws FilesystemException
      *
      * @return void
      */


### PR DESCRIPTION
Hello,

phpstan v2 complains about catching `FileNotFoundException` when calling the `Server::getImageResponse`.
But `makeImage` can actually throw those errors, so i've added them into the public methods