### PR TITLE
Encode using media type instead of extension

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -44,7 +44,7 @@ jobs:
         uses: codecov/codecov-action@v3
 
   coding-style:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -61,7 +61,7 @@ jobs:
           vendor/bin/php-cs-fixer fix --dry-run --diff --allow-risky=yes
 
   static-analysis:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         {
             "name": "Jonathan Reinink",
             "email": "jonathan@reinink.ca",
-            "homepage": "http://reinink.ca"
+            "homepage": "https://reinink.ca/"
         },
         {
             "name": "Titouan Galopin",

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -26,8 +26,8 @@ class Api implements ApiInterface
     /**
      * Create API instance.
      *
-     * @param ImageManager                    $imageManager Intervention image manager.
-     * @param list<ManipulatorInterface|null> $manipulators Collection of manipulators.
+     * @param ImageManager               $imageManager Intervention image manager.
+     * @param list<ManipulatorInterface> $manipulators Collection of manipulators.
      */
     public function __construct(ImageManager $imageManager, array $manipulators)
     {
@@ -59,6 +59,8 @@ class Api implements ApiInterface
      * Set the manipulators.
      *
      * @param array $manipulators Collection of manipulators.
+     *
+     * @throws \InvalidArgumentException
      */
     public function setManipulators(array $manipulators): void
     {

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -27,7 +27,7 @@ class Api implements ApiInterface
      * Create API instance.
      *
      * @param ImageManager $imageManager Intervention image manager.
-     * @param array        $manipulators Collection of manipulators.
+     * @param list<ManipulatorInterface|null> $manipulators Collection of manipulators.
      */
     public function __construct(ImageManager $imageManager, array $manipulators)
     {
@@ -58,17 +58,11 @@ class Api implements ApiInterface
     /**
      * Set the manipulators.
      *
-     * @param ManipulatorInterface[] $manipulators Collection of manipulators.
+     * @param list<ManipulatorInterface|null> $manipulators Collection of manipulators.
      */
     public function setManipulators(array $manipulators): void
     {
-        foreach ($manipulators as $manipulator) {
-            if (!($manipulator instanceof ManipulatorInterface)) {
-                throw new \InvalidArgumentException('Not a valid manipulator.');
-            }
-        }
-
-        $this->manipulators = $manipulators;
+        $this->manipulators = array_filter($manipulators, fn ($manipulator) => $manipulator instanceof ManipulatorInterface);
     }
 
     /**

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -26,7 +26,7 @@ class Api implements ApiInterface
     /**
      * Create API instance.
      *
-     * @param ImageManager $imageManager Intervention image manager.
+     * @param ImageManager                    $imageManager Intervention image manager.
      * @param list<ManipulatorInterface|null> $manipulators Collection of manipulators.
      */
     public function __construct(ImageManager $imageManager, array $manipulators)

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -62,7 +62,13 @@ class Api implements ApiInterface
      */
     public function setManipulators(array $manipulators): void
     {
-        $this->manipulators = array_filter($manipulators, fn ($manipulator) => $manipulator instanceof ManipulatorInterface);
+        foreach ($manipulators as $manipulator) {
+            if (!($manipulator instanceof ManipulatorInterface)) {
+                throw new \InvalidArgumentException('Not a valid manipulator.');
+            }
+        }
+
+        $this->manipulators = $manipulators; // @phpstan-ignore-line
     }
 
     /**

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -58,17 +58,11 @@ class Api implements ApiInterface
     /**
      * Set the manipulators.
      *
-     * @param list<ManipulatorInterface|null> $manipulators Collection of manipulators.
+     * @param array $manipulators Collection of manipulators.
      */
     public function setManipulators(array $manipulators): void
     {
-        foreach ($manipulators as $manipulator) {
-            if (!($manipulator instanceof ManipulatorInterface)) {
-                throw new \InvalidArgumentException('Not a valid manipulator.');
-            }
-        }
-
-        $this->manipulators = $manipulators; // @phpstan-ignore-line
+        $this->manipulators = array_filter($manipulators, fn ($manipulator) => $manipulator instanceof ManipulatorInterface || throw new \InvalidArgumentException('Not a valid manipulator.'));
     }
 
     /**

--- a/src/Api/Encoder.php
+++ b/src/Api/Encoder.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace League\Glide\Api;
 
-use Intervention\Image\FileExtension;
-use Intervention\Image\Format;
 use Intervention\Image\Interfaces\EncodedImageInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\MediaType;

--- a/src/Api/Encoder.php
+++ b/src/Api/Encoder.php
@@ -102,8 +102,7 @@ class Encoder
             $mediaType = $this->getMediaType($image);
 
             return $mediaType->format()->fileExtension()->value;
-        } catch (\Exception $e) {
-            var_dump($e->getMessage());
+        } catch (\Exception) {
             return 'jpg';
         }
     }

--- a/src/Api/Encoder.php
+++ b/src/Api/Encoder.php
@@ -79,14 +79,16 @@ class Encoder
         $fm = (string) $this->getParam('fm');
 
         if ($fm !== '') {
-            return self::supportedFormats()[$fm] ?? throw new \Exception("Invalid format provided: {$fm}");
+            $mediaType = self::supportedFormats()[$fm] ?? throw new \Exception("Invalid format provided: {$fm}");
+        } else {
+            try {
+                $mediaType = MediaType::tryFrom($image->origin()->mediaType());
+            } catch (\Exception) {
+                $mediaType = MediaType::IMAGE_JPEG;
+            }
         }
 
-        try {
-            return MediaType::tryFrom($image->origin()->mediaType());
-        } catch (\Exception) {
-            return MediaType::IMAGE_JPEG;
-        }
+        return $image->driver()->supports($mediaType) ? $mediaType : throw new \Exception("Unsupported format: {$mediaType->value}");
     }
 
     /**
@@ -116,7 +118,7 @@ class Encoder
     {
         return [
             'avif' => MediaType::IMAGE_AVIF,
-            'bpm' => MediaType::IMAGE_BMP,
+            'bmp' => MediaType::IMAGE_BMP,
             'gif' => MediaType::IMAGE_GIF,
             'heic' => MediaType::IMAGE_HEIC,
             'jpg' => MediaType::IMAGE_JPEG,

--- a/src/Api/Encoder.php
+++ b/src/Api/Encoder.php
@@ -110,9 +110,8 @@ class Encoder
     {
         try {
             $mediaType = $this->getMediaType($image);
-            $extensions = $mediaType->format()->fileExtensions();
 
-            return reset($extensions)->value; // @phpstan-ignore-line
+            return array_search($mediaType->value, self::supportedFormats(), true) ?: 'jpg';
         } catch (\Exception) {
             return 'jpg';
         }

--- a/src/Api/Encoder.php
+++ b/src/Api/Encoder.php
@@ -79,16 +79,14 @@ class Encoder
         $fm = (string) $this->getParam('fm');
 
         if ('' !== $fm) {
-            $mediaType = self::supportedFormats()[$fm] ?? throw new \Exception("Invalid format provided: {$fm}");
-        } else {
-            try {
-                $mediaType = MediaType::tryFrom($image->origin()->mediaType());
-            } catch (\Exception) {
-                $mediaType = MediaType::IMAGE_JPEG;
-            }
+            return self::supportedFormats()[$fm] ?? throw new \Exception("Invalid format provided: {$fm}");
         }
 
-        return $image->driver()->supports($mediaType) ? $mediaType : throw new \Exception("Unsupported format: {$mediaType->value}");
+        try {
+            return MediaType::tryFrom($image->origin()->mediaType());
+        } catch (\Exception) {
+            return MediaType::IMAGE_JPEG;
+        }
     }
 
     /**
@@ -104,7 +102,8 @@ class Encoder
             $mediaType = $this->getMediaType($image);
 
             return $mediaType->format()->fileExtension()->value;
-        } catch (\Exception) {
+        } catch (\Exception $e) {
+            var_dump($e->getMessage());
             return 'jpg';
         }
     }

--- a/src/Api/Encoder.php
+++ b/src/Api/Encoder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace League\Glide\Api;
 
+use Intervention\Image\Format;
 use Intervention\Image\Interfaces\EncodedImageInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\MediaType;
@@ -77,17 +78,8 @@ class Encoder
     {
         $fm = (string) $this->getParam('fm');
 
-        if ($fm && array_key_exists($fm, static::supportedFormats())) {
-            return match ($fm) {
-                'avif' => MediaType::IMAGE_AVIF,
-                'gif' => MediaType::IMAGE_GIF,
-                'jpg' => MediaType::IMAGE_JPEG,
-                'pjpg' => MediaType::IMAGE_PJPEG,
-                'png' => MediaType::IMAGE_PNG,
-                'webp' => MediaType::IMAGE_WEBP,
-                'tiff' => MediaType::IMAGE_TIFF,
-                'heic' => MediaType::IMAGE_HEIC,
-            };
+        if ($fm !== '') {
+            return self::supportedFormats()[$fm] ?? throw new \Exception("Invalid format provided: {$fm}");
         }
 
         try {
@@ -106,17 +98,10 @@ class Encoder
      */
     public function getFormat(ImageInterface $image): string
     {
-        $fm = (string) $this->getParam('fm');
-
-        if ($fm && array_key_exists($fm, static::supportedFormats())) {
-            return $fm;
-        }
-
         try {
-            $format    = MediaType::tryFrom($image->origin()->mediaType())->format();
-            $extension = $format->fileExtension()->value;
+            $mediaType = $this->getMediaType($image);
 
-            return isset(static::supportedFormats()[$extension]) ? $extension : 'jpg';
+            return $mediaType->format()->fileExtension()->value;
         } catch (\Exception) {
             return 'jpg';
         }
@@ -125,19 +110,20 @@ class Encoder
     /**
      * Get a list of supported image formats and MIME types.
      *
-     * @return array<string,string>
+     * @return array<string,MediaType>
      */
     public static function supportedFormats(): array
     {
         return [
-            'avif' => 'image/avif',
-            'gif' => 'image/gif',
-            'jpg' => 'image/jpeg',
-            'pjpg' => 'image/jpeg',
-            'png' => 'image/png',
-            'webp' => 'image/webp',
-            'tiff' => 'image/tiff',
-            'heic' => 'image/heic',
+            'avif' => MediaType::IMAGE_AVIF,
+            'bpm' => MediaType::IMAGE_BMP,
+            'gif' => MediaType::IMAGE_GIF,
+            'heic' => MediaType::IMAGE_HEIC,
+            'jpg' => MediaType::IMAGE_JPEG,
+            'pjpg' => MediaType::IMAGE_PJPEG,
+            'png' => MediaType::IMAGE_PNG,
+            'tiff' => MediaType::IMAGE_TIFF,
+            'webp' => MediaType::IMAGE_WEBP,
         ];
     }
 

--- a/src/Api/Encoder.php
+++ b/src/Api/Encoder.php
@@ -89,7 +89,7 @@ class Encoder
         $fm = (string) $this->getParam('fm');
 
         if ('' !== $fm) {
-            return self::supportedFormats()[$fm] ?? throw new \Exception("Invalid format provided: {$fm}");
+            return self::supportedMediaTypes()[$fm] ?? throw new \Exception("Invalid format provided: {$fm}");
         }
 
         try {
@@ -121,9 +121,19 @@ class Encoder
     /**
      * Get a list of supported image formats and MIME types.
      *
-     * @return array<string,MediaType>
+     * @return array<string,string>
      */
     public static function supportedFormats(): array
+    {
+        return array_map(fn (MediaType $mediaType) => $mediaType->value, self::supportedMediaTypes());
+    }
+
+    /**
+     * Get a list of supported image formats and media types.
+     *
+     * @return array<string,MediaType>
+     */
+    public static function supportedMediaTypes(): array
     {
         return [
             'avif' => MediaType::IMAGE_AVIF,

--- a/src/Api/Encoder.php
+++ b/src/Api/Encoder.php
@@ -68,7 +68,7 @@ class Encoder
 
         $encoderOptions = array_filter([
             'quality' => $quality,
-            'interlaced' => $mediaType === MediaType::IMAGE_PNG ? $shouldInterlace : null,
+            'interlaced' => MediaType::IMAGE_PNG === $mediaType ? $shouldInterlace : null,
         ]);
 
         return $image->encodeByMediaType($mediaType, ...$encoderOptions);
@@ -78,7 +78,7 @@ class Encoder
     {
         $fm = (string) $this->getParam('fm');
 
-        if ($fm !== '') {
+        if ('' !== $fm) {
             $mediaType = self::supportedFormats()[$fm] ?? throw new \Exception("Invalid format provided: {$fm}");
         } else {
             try {

--- a/src/Api/Encoder.php
+++ b/src/Api/Encoder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace League\Glide\Api;
 
+use Intervention\Image\FileExtension;
 use Intervention\Image\Format;
 use Intervention\Image\Interfaces\EncodedImageInterface;
 use Intervention\Image\Interfaces\ImageInterface;
@@ -110,10 +111,10 @@ class Encoder
     public function getFormat(ImageInterface $image): string
     {
         try {
-            $mediaType  = $this->getMediaType($image);
+            $mediaType = $this->getMediaType($image);
             $extensions = $mediaType->format()->fileExtensions();
 
-            return reset($extensions)->value;
+            return reset($extensions)->value; // @phpstan-ignore-line
         } catch (\Exception) {
             return 'jpg';
         }

--- a/src/Api/Encoder.php
+++ b/src/Api/Encoder.php
@@ -105,6 +105,8 @@ class Encoder
      * @param ImageInterface $image The source image.
      *
      * @return string The resolved format.
+     *
+     * @psalm-suppress RiskyTruthyFalsyComparison
      */
     public function getFormat(ImageInterface $image): string
     {

--- a/src/Api/Encoder.php
+++ b/src/Api/Encoder.php
@@ -63,7 +63,7 @@ class Encoder
     public function run(ImageInterface $image): EncodedImageInterface
     {
         $encoderOptions = [];
-        $mediaType      = $this->getMediaType($image);
+        $mediaType = $this->getMediaType($image);
 
         if (MediaType::IMAGE_PJPEG === $mediaType) {
             $encoderOptions['progressive'] = true;
@@ -110,9 +110,10 @@ class Encoder
     public function getFormat(ImageInterface $image): string
     {
         try {
-            $mediaType = $this->getMediaType($image);
+            $mediaType  = $this->getMediaType($image);
+            $extensions = $mediaType->format()->fileExtensions();
 
-            return $mediaType->format()->fileExtension()->value;
+            return reset($extensions)->value;
         } catch (\Exception) {
             return 'jpg';
         }

--- a/src/Api/Encoder.php
+++ b/src/Api/Encoder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace League\Glide\Api;
 
-use Intervention\Image\Format;
 use Intervention\Image\Interfaces\EncodedImageInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\MediaType;
@@ -64,19 +63,31 @@ class Encoder
     {
         $mediaType = $this->getMediaType($image);
 
-        $encoderOptions = [
-            'shouldInterlace' => filter_var($this->getParam('interlace'), FILTER_VALIDATE_BOOLEAN),
-            'quality' => $this->getQuality(),
-            'progressive' => null,
-        ];
-
         if (MediaType::IMAGE_PJPEG === $mediaType) {
             $encoderOptions['progressive'] = true;
+        }
+
+        if (
+            MediaType::IMAGE_PNG !== $mediaType
+            || MediaType::IMAGE_GIF !== $mediaType
+        ) {
+            $encoderOptions['quality'] = $this->getQuality();
+        } else {
+            $encoderOptions['interlaced'] = filter_var($this->getParam('interlace'), FILTER_VALIDATE_BOOLEAN);
         }
 
         return $mediaType->format()->encoder(...array_filter($encoderOptions))->encode($image);
     }
 
+    /**
+     * Resolve media type.
+     *
+     * @param ImageInterface $image
+     *
+     * @throws \Exception
+     *
+     * @return MediaType
+     */
     public function getMediaType(ImageInterface $image): MediaType
     {
         $fm = (string) $this->getParam('fm');

--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -18,6 +18,7 @@ use League\Glide\Manipulators\Crop;
 use League\Glide\Manipulators\Filter;
 use League\Glide\Manipulators\Flip;
 use League\Glide\Manipulators\Gamma;
+use League\Glide\Manipulators\ManipulatorInterface;
 use League\Glide\Manipulators\Orientation;
 use League\Glide\Manipulators\Pixelate;
 use League\Glide\Manipulators\Sharpen;
@@ -237,7 +238,7 @@ class ServerFactory
     /**
      * Get image manipulators.
      *
-     * @return array Image manipulators.
+     * @return list<ManipulatorInterface> Image manipulators.
      */
     public function getManipulators(): array
     {

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -8,7 +8,6 @@ use Intervention\Image\ImageManager;
 use Intervention\Image\Interfaces\DriverInterface;
 use Intervention\Image\Interfaces\EncodedImageInterface;
 use Intervention\Image\Interfaces\ImageInterface;
-use Intervention\Image\MediaType;
 use Intervention\Image\Origin;
 use League\Glide\Manipulators\ManipulatorInterface;
 use PHPUnit\Framework\TestCase;

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class ApiTest extends TestCase
 {
-    private $api;
+    private Api $api;
 
     public function setUp(): void
     {
@@ -26,30 +26,30 @@ class ApiTest extends TestCase
         \Mockery::close();
     }
 
-    public function testCreateInstance()
+    public function testCreateInstance(): void
     {
         $this->assertInstanceOf(Api::class, $this->api);
     }
 
-    public function testSetImageManager()
+    public function testSetImageManager(): void
     {
         $this->api->setImageManager(ImageManager::gd());
         $this->assertInstanceOf(ImageManager::class, $this->api->getImageManager());
     }
 
-    public function testGetImageManager()
+    public function testGetImageManager(): void
     {
         $this->assertInstanceOf(ImageManager::class, $this->api->getImageManager());
     }
 
-    public function testSetManipulators()
+    public function testSetManipulators(): void
     {
         $this->api->setManipulators([\Mockery::mock(ManipulatorInterface::class)]);
         $manipulators = $this->api->getManipulators();
         $this->assertInstanceOf(ManipulatorInterface::class, $manipulators[0]);
     }
 
-    public function testSetInvalidManipulator()
+    public function testSetInvalidManipulator(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Not a valid manipulator.');
@@ -57,12 +57,12 @@ class ApiTest extends TestCase
         $this->api->setManipulators([new \stdClass()]);
     }
 
-    public function testGetManipulators()
+    public function testGetManipulators(): void
     {
         $this->assertEquals([], $this->api->getManipulators());
     }
 
-    public function testRun()
+    public function testRun(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('origin')->andReturn(\Mockery::mock(Origin::class, function ($mock) {
@@ -88,7 +88,7 @@ class ApiTest extends TestCase
         $api = new Api($manager, [$manipulator]);
 
         $this->assertEquals('encoded', $api->run(
-            file_get_contents(dirname(__FILE__, 2).'/files/red-pixel.png'),
+            (string) file_get_contents(dirname(__FILE__, 2).'/files/red-pixel.png'),
             []
         ));
     }

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -7,6 +7,7 @@ namespace League\Glide\Api;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Interfaces\EncodedImageInterface;
 use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\MediaType;
 use League\Glide\Manipulators\ManipulatorInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -68,6 +69,10 @@ class ApiTest extends TestCase
             }));
 
             $mock->shouldReceive('encodeByExtension')->with('png')->andReturn(\Mockery::mock(EncodedImageInterface::class, function ($mock) {
+                $mock->shouldReceive('toString')->andReturn('encoded');
+            }));
+
+            $mock->shouldReceive('encodeByMediaType')->with(MediaType::IMAGE_PNG)->andReturn(\Mockery::mock(EncodedImageInterface::class, function ($mock) {
                 $mock->shouldReceive('toString')->andReturn('encoded');
             }));
         });

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace League\Glide\Api;
 
 use Intervention\Image\ImageManager;
+use Intervention\Image\Interfaces\DriverInterface;
 use Intervention\Image\Interfaces\EncodedImageInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\MediaType;
+use Intervention\Image\Origin;
 use League\Glide\Manipulators\ManipulatorInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -64,7 +66,7 @@ class ApiTest extends TestCase
     public function testRun()
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
-            $mock->shouldReceive('origin')->andReturn(\Mockery::mock('\Intervention\Image\Origin', function ($mock) {
+            $mock->shouldReceive('origin')->andReturn(\Mockery::mock(Origin::class, function ($mock) {
                 $mock->shouldReceive('mediaType')->andReturn('image/png');
             }));
 
@@ -74,6 +76,10 @@ class ApiTest extends TestCase
 
             $mock->shouldReceive('encodeByMediaType')->with(MediaType::IMAGE_PNG)->andReturn(\Mockery::mock(EncodedImageInterface::class, function ($mock) {
                 $mock->shouldReceive('toString')->andReturn('encoded');
+            }));
+
+            $mock->shouldReceive('driver')->andReturn(\Mockery::mock(DriverInterface::class, function ($mock) {
+                $mock->shouldReceive('supports');
             }));
         });
 

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -70,16 +70,12 @@ class ApiTest extends TestCase
                 $mock->shouldReceive('mediaType')->andReturn('image/png');
             }));
 
-            $mock->shouldReceive('encodeByExtension')->with('png')->andReturn(\Mockery::mock(EncodedImageInterface::class, function ($mock) {
-                $mock->shouldReceive('toString')->andReturn('encoded');
-            }));
-
-            $mock->shouldReceive('encodeByMediaType')->with(MediaType::IMAGE_PNG)->andReturn(\Mockery::mock(EncodedImageInterface::class, function ($mock) {
-                $mock->shouldReceive('toString')->andReturn('encoded');
-            }));
-
             $mock->shouldReceive('driver')->andReturn(\Mockery::mock(DriverInterface::class, function ($mock) {
                 $mock->shouldReceive('supports');
+            }));
+
+            $mock->shouldReceive('encode')->andReturn(\Mockery::mock(EncodedImageInterface::class, function ($mock) {
+                $mock->shouldReceive('toString')->andReturn('encoded');
             }));
         });
 

--- a/tests/Api/EncoderTest.php
+++ b/tests/Api/EncoderTest.php
@@ -236,7 +236,7 @@ class EncoderTest extends TestCase
         return $mock->shouldReceive('origin')
             ->andReturn(\Mockery::mock(Origin::class, ['mediaType' => $mediaType]))
             ->shouldReceive('driver')
-            ->andReturn(\Mockery::mock(DriverInterface::class , function ($mock) {
+            ->andReturn(\Mockery::mock(DriverInterface::class, function ($mock) {
                 $mock->shouldReceive('supports');
             }));
     }

--- a/tests/Api/EncoderTest.php
+++ b/tests/Api/EncoderTest.php
@@ -6,9 +6,11 @@ namespace League\Glide\Api;
 
 use Intervention\Image\Encoders\MediaTypeEncoder;
 use Intervention\Image\ImageManager;
+use Intervention\Image\Interfaces\DriverInterface;
 use Intervention\Image\Interfaces\EncodedImageInterface;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\MediaType;
+use Intervention\Image\Origin;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
@@ -147,7 +149,6 @@ class EncoderTest extends TestCase
         $this->assertSame('jpg', $this->encoder->setParams(['fm' => null])->getFormat($image));
         $this->assertSame('png', $this->encoder->setParams(['fm' => null])->getFormat($image));
         $this->assertSame('gif', $this->encoder->setParams(['fm' => null])->getFormat($image));
-        $this->assertSame('bmp', $this->encoder->setParams(['fm' => null])->getFormat($image));
         $this->assertSame('jpg', $this->encoder->setParams(['fm' => null])->getFormat($image));
 
         $this->assertSame('jpg', $this->encoder->setParams(['fm' => ''])->getFormat($image));
@@ -201,7 +202,7 @@ class EncoderTest extends TestCase
     {
         $expected = [
             'avif' => MediaType::IMAGE_AVIF,
-            'bpm' => MediaType::IMAGE_BMP,
+            'bmp' => MediaType::IMAGE_BMP,
             'gif' => MediaType::IMAGE_GIF,
             'heic' => MediaType::IMAGE_HEIC,
             'jpg' => MediaType::IMAGE_JPEG,
@@ -229,12 +230,14 @@ class EncoderTest extends TestCase
      */
     protected function assertMediaType($mock, $mediaType): Mockery\CompositeExpectation
     {
-        /*
-         * @var Mock $mock
-         */
         /**
          * @psalm-suppress LessSpecificReturnStatement, UndefinedMagicMethod
          */
-        return $mock->shouldReceive('origin')->andReturn(\Mockery::mock('Intervention\Image\Origin', ['mediaType' => $mediaType]));
+        return $mock->shouldReceive('origin')
+            ->andReturn(\Mockery::mock(Origin::class, ['mediaType' => $mediaType]))
+            ->shouldReceive('driver')
+            ->andReturn(\Mockery::mock(DriverInterface::class , function ($mock) {
+                $mock->shouldReceive('supports');
+            }));
     }
 }

--- a/tests/Api/EncoderTest.php
+++ b/tests/Api/EncoderTest.php
@@ -130,12 +130,14 @@ class EncoderTest extends TestCase
         $this->assertSame('png', $this->encoder->setParams(['fm' => 'png'])->getFormat($this->getImageByMimeType('image/jpeg')));
         $this->assertSame('gif', $this->encoder->setParams(['fm' => 'gif'])->getFormat($this->getImageByMimeType('image/jpeg')));
         $this->assertSame('bmp', $this->encoder->setParams(['fm' => 'bmp'])->getFormat($this->getImageByMimeType('image/jpeg')));
+        $this->assertSame('pjpg', $this->encoder->setParams(['fm' => 'pjpg'])->getFormat($this->getImageByMimeType('image/jpeg')));
 
         // Make sure we keep the current format if no format is provided
         $this->assertSame('jpg', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/jpeg')));
         $this->assertSame('png', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/png')));
         $this->assertSame('gif', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/gif')));
         $this->assertSame('bmp', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/bmp')));
+        $this->assertSame('jpg', $this->encoder->setParams(['fm' => 'null'])->getFormat($this->getImageByMimeType('image/pjpeg')));
 
         $this->assertSame('jpg', $this->encoder->setParams(['fm' => ''])->getFormat($this->getImageByMimeType('image/jpeg')));
         $this->assertSame('png', $this->encoder->setParams(['fm' => ''])->getFormat($this->getImageByMimeType('image/png')));

--- a/tests/Api/EncoderTest.php
+++ b/tests/Api/EncoderTest.php
@@ -8,6 +8,7 @@ use Intervention\Image\Encoders\MediaTypeEncoder;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Interfaces\EncodedImageInterface;
 use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\MediaType;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
@@ -146,6 +147,7 @@ class EncoderTest extends TestCase
         $this->assertSame('jpg', $this->encoder->setParams(['fm' => null])->getFormat($image));
         $this->assertSame('png', $this->encoder->setParams(['fm' => null])->getFormat($image));
         $this->assertSame('gif', $this->encoder->setParams(['fm' => null])->getFormat($image));
+        $this->assertSame('bmp', $this->encoder->setParams(['fm' => null])->getFormat($image));
         $this->assertSame('jpg', $this->encoder->setParams(['fm' => null])->getFormat($image));
 
         $this->assertSame('jpg', $this->encoder->setParams(['fm' => ''])->getFormat($image));
@@ -198,14 +200,15 @@ class EncoderTest extends TestCase
     public function testSupportedFormats(): void
     {
         $expected = [
-            'avif' => 'image/avif',
-            'gif' => 'image/gif',
-            'jpg' => 'image/jpeg',
-            'pjpg' => 'image/jpeg',
-            'png' => 'image/png',
-            'webp' => 'image/webp',
-            'tiff' => 'image/tiff',
-            'heic' => 'image/heic',
+            'avif' => MediaType::IMAGE_AVIF,
+            'bpm' => MediaType::IMAGE_BMP,
+            'gif' => MediaType::IMAGE_GIF,
+            'heic' => MediaType::IMAGE_HEIC,
+            'jpg' => MediaType::IMAGE_JPEG,
+            'pjpg' => MediaType::IMAGE_PJPEG,
+            'png' => MediaType::IMAGE_PNG,
+            'tiff' => MediaType::IMAGE_TIFF,
+            'webp' => MediaType::IMAGE_WEBP,
         ];
 
         $this->assertSame($expected, Encoder::supportedFormats());

--- a/tests/Api/EncoderTest.php
+++ b/tests/Api/EncoderTest.php
@@ -19,6 +19,7 @@ class EncoderTest extends TestCase
     private ImageInterface $gif;
     private ImageInterface $tif;
     private ImageInterface $webp;
+    private ImageInterface $webpx;
     private ImageInterface $avif;
     private ImageInterface $heic;
 
@@ -38,6 +39,9 @@ class EncoderTest extends TestCase
         if (function_exists('imagecreatefromwebp')) {
             $this->webp = $manager->read(
                 $manager->create(100, 100)->encode(new MediaTypeEncoder('image/webp'))->toFilePointer()
+            );
+            $this->webpx = $manager->read(
+                $manager->create(100, 100)->encode(new MediaTypeEncoder('image/x-webp'))->toFilePointer()
             );
         }
 
@@ -87,6 +91,12 @@ class EncoderTest extends TestCase
             $this->assertSame('image/webp', $this->getMime($this->encoder->setParams(['fm' => 'webp'])->run($this->png)));
             $this->assertSame('image/webp', $this->getMime($this->encoder->setParams(['fm' => 'webp'])->run($this->gif)));
             $this->assertSame('image/webp', $this->getMime($this->encoder->setParams(['fm' => 'webp'])->run($this->webp)));
+
+            $this->assertSame('image/jpeg', $this->getMime($this->encoder->setParams(['fm' => 'jpg'])->run($this->webpx)));
+            $this->assertSame('image/jpeg', $this->getMime($this->encoder->setParams(['fm' => 'pjpg'])->run($this->webpx)));
+            $this->assertSame('image/png', $this->getMime($this->encoder->setParams(['fm' => 'png'])->run($this->webpx)));
+            $this->assertSame('image/gif', $this->getMime($this->encoder->setParams(['fm' => 'gif'])->run($this->webpx)));
+            $this->assertSame('image/webp', $this->getMime($this->encoder->setParams(['fm' => 'webp'])->run($this->webpx)));
         }
         if (function_exists('imagecreatefromavif')) {
             $this->assertSame('image/jpeg', $this->getMime($this->encoder->setParams(['fm' => 'jpg'])->run($this->avif)));
@@ -102,6 +112,7 @@ class EncoderTest extends TestCase
         if (function_exists('imagecreatefromwebp') && function_exists('imagecreatefromavif')) {
             $this->assertSame('image/webp', $this->getMime($this->encoder->setParams(['fm' => 'webp'])->run($this->avif)));
             $this->assertSame('image/avif', $this->getMime($this->encoder->setParams(['fm' => 'avif'])->run($this->webp)));
+            $this->assertSame('image/avif', $this->getMime($this->encoder->setParams(['fm' => 'avif'])->run($this->webpx)));
         }
     }
 

--- a/tests/Api/EncoderTest.php
+++ b/tests/Api/EncoderTest.php
@@ -121,46 +121,35 @@ class EncoderTest extends TestCase
 
     public function testGetFormat(): void
     {
-        /**
-         * @psalm-suppress MissingClosureParamType
-         */
-        $image = \Mockery::mock(ImageInterface::class, function ($mock) {
-            /*
-             * @var Mock $mock
-             */
-            $this->assertMediaType($mock, 'image/jpeg')->once();
-            $this->assertMediaType($mock, 'image/png')->once();
-            $this->assertMediaType($mock, 'image/gif')->once();
-            $this->assertMediaType($mock, 'image/bmp')->once();
-            $this->assertMediaType($mock, 'image/jpeg')->twice();
+        $this->assertSame('jpg', $this->encoder->setParams(['fm' => 'jpg'])->getFormat($this->getImageByMimeType('image/jpeg')));
+        $this->assertSame('png', $this->encoder->setParams(['fm' => 'png'])->getFormat($this->getImageByMimeType('image/png')));
+        $this->assertSame('gif', $this->encoder->setParams(['fm' => 'gif'])->getFormat($this->getImageByMimeType('image/gif')));
+        $this->assertSame('bmp', $this->encoder->setParams(['fm' => 'bmp'])->getFormat($this->getImageByMimeType('image/bmp')));
 
-            if (function_exists('imagecreatefromwebp')) {
-                $this->assertMediaType($mock, 'image/webp')->once();
-            }
+        // Make sure we keep the current format if no format is provided
+        $this->assertSame('jpg', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/jpeg')));
+        $this->assertSame('png', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/png')));
+        $this->assertSame('gif', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/gif')));
+        $this->assertSame('bmp', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/bmp')));
 
-            if (function_exists('imagecreatefromavif')) {
-                $this->assertMediaType($mock, 'image/avif')->once();
-            }
-        });
-
-        $this->assertSame('jpg', $this->encoder->setParams(['fm' => 'jpg'])->getFormat($image));
-        $this->assertSame('png', $this->encoder->setParams(['fm' => 'png'])->getFormat($image));
-        $this->assertSame('gif', $this->encoder->setParams(['fm' => 'gif'])->getFormat($image));
-        $this->assertSame('jpg', $this->encoder->setParams(['fm' => null])->getFormat($image));
-        $this->assertSame('png', $this->encoder->setParams(['fm' => null])->getFormat($image));
-        $this->assertSame('gif', $this->encoder->setParams(['fm' => null])->getFormat($image));
-        $this->assertSame('jpg', $this->encoder->setParams(['fm' => null])->getFormat($image));
-
-        $this->assertSame('jpg', $this->encoder->setParams(['fm' => ''])->getFormat($image));
-        $this->assertSame('jpg', $this->encoder->setParams(['fm' => 'invalid'])->getFormat($image));
+        $this->assertSame('jpg', $this->encoder->setParams(['fm' => ''])->getFormat($this->getImageByMimeType('image/jpeg')));
+        $this->assertSame('png', $this->encoder->setParams(['fm' => ''])->getFormat($this->getImageByMimeType('image/png')));
+        $this->assertSame('jpg', $this->encoder->setParams(['fm' => 'invalid'])->getFormat($this->getImageByMimeType('image/jpeg')));
 
         if (function_exists('imagecreatefromwebp')) {
-            $this->assertSame('webp', $this->encoder->setParams(['fm' => null])->getFormat($image));
+            $this->assertSame('webp', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/webp')));
         }
 
         if (function_exists('imagecreatefromavif')) {
-            $this->assertSame('avif', $this->encoder->setParams(['fm' => null])->getFormat($image));
+            $this->assertSame('avif', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/avif')));
         }
+    }
+
+    protected function getImageByMimeType(string $mimeType): ImageInterface
+    {
+        return \Mockery::mock(ImageInterface::class, function ($mock) use ($mimeType) {
+            $this->assertMediaType($mock, $mimeType);
+        });
     }
 
     public function testGetQuality(): void

--- a/tests/Api/EncoderTest.php
+++ b/tests/Api/EncoderTest.php
@@ -183,6 +183,7 @@ class EncoderTest extends TestCase
             );
         }
         $manager = ImageManager::imagick();
+
         // These need to be recreated with the imagick driver selected in the manager
         $this->jpg = $manager->read($manager->create(100, 100)->encode(new MediaTypeEncoder('image/jpeg'))->toFilePointer());
         $this->png = $manager->read($manager->create(100, 100)->encode(new MediaTypeEncoder('image/png'))->toFilePointer());

--- a/tests/Api/EncoderTest.php
+++ b/tests/Api/EncoderTest.php
@@ -126,6 +126,11 @@ class EncoderTest extends TestCase
         $this->assertSame('gif', $this->encoder->setParams(['fm' => 'gif'])->getFormat($this->getImageByMimeType('image/gif')));
         $this->assertSame('bmp', $this->encoder->setParams(['fm' => 'bmp'])->getFormat($this->getImageByMimeType('image/bmp')));
 
+        // Make sure 'fm' parameter takes precedence
+        $this->assertSame('png', $this->encoder->setParams(['fm' => 'png'])->getFormat($this->getImageByMimeType('image/jpeg')));
+        $this->assertSame('gif', $this->encoder->setParams(['fm' => 'gif'])->getFormat($this->getImageByMimeType('image/jpeg')));
+        $this->assertSame('bmp', $this->encoder->setParams(['fm' => 'bmp'])->getFormat($this->getImageByMimeType('image/jpeg')));
+
         // Make sure we keep the current format if no format is provided
         $this->assertSame('jpg', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/jpeg')));
         $this->assertSame('png', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/png')));
@@ -138,10 +143,12 @@ class EncoderTest extends TestCase
 
         if (function_exists('imagecreatefromwebp')) {
             $this->assertSame('webp', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/webp')));
+            $this->assertSame('webp', $this->encoder->setParams(['fm' => 'webp'])->getFormat($this->getImageByMimeType('image/jpeg')));
         }
 
         if (function_exists('imagecreatefromavif')) {
             $this->assertSame('avif', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/avif')));
+            $this->assertSame('avif', $this->encoder->setParams(['fm' => 'avif'])->getFormat($this->getImageByMimeType('image/jpeg')));
         }
     }
 
@@ -190,6 +197,23 @@ class EncoderTest extends TestCase
     public function testSupportedFormats(): void
     {
         $expected = [
+            'avif' => 'image/avif',
+            'bmp' => 'image/bmp',
+            'gif' => 'image/gif',
+            'heic' => 'image/heic',
+            'jpg' => 'image/jpeg',
+            'pjpg' => 'image/pjpeg',
+            'png' => 'image/png',
+            'tiff' => 'image/tiff',
+            'webp' => 'image/webp',
+        ];
+
+        $this->assertSame($expected, Encoder::supportedFormats());
+    }
+
+    public function testSupportedMediaTypes(): void
+    {
+        $expected = [
             'avif' => MediaType::IMAGE_AVIF,
             'bmp' => MediaType::IMAGE_BMP,
             'gif' => MediaType::IMAGE_GIF,
@@ -201,7 +225,7 @@ class EncoderTest extends TestCase
             'webp' => MediaType::IMAGE_WEBP,
         ];
 
-        $this->assertSame($expected, Encoder::supportedFormats());
+        $this->assertSame($expected, Encoder::supportedMediaTypes());
     }
 
     protected function getMime(EncodedImageInterface $image): string
@@ -212,12 +236,11 @@ class EncoderTest extends TestCase
     /**
      * Creates an assertion to check media type.
      *
-     * @param Mock   $mock
-     * @param string $mediaType
+     * @param Mockery\Mock $mock
      *
      * @psalm-suppress MoreSpecificReturnType
      */
-    protected function assertMediaType($mock, $mediaType): Mockery\CompositeExpectation
+    protected function assertMediaType($mock, string $mediaType): Mockery\CompositeExpectation
     {
         /**
          * @psalm-suppress LessSpecificReturnStatement, UndefinedMagicMethod


### PR DESCRIPTION
If an image had `image/x-webp` or another format supported by `Intervention` but not defined in `supportedFormats`, it would fail.

This uses `encodeByMediaType` instead which uses the proper values and available formats defined by `Intervention`