### PR TITLE
Define API params in order to be able to filter correctly

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -44,7 +44,7 @@ jobs:
         uses: codecov/codecov-action@v3
 
   coding-style:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -61,7 +61,7 @@ jobs:
           vendor/bin/php-cs-fixer fix --dry-run --diff --allow-risky=yes
 
   static-analysis:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -11,6 +11,13 @@ use League\Glide\Manipulators\ManipulatorInterface;
 
 class Api implements ApiInterface
 {
+    public const GLOBAL_API_PARAMS = [
+        'p', // presets
+        'q', // quality
+        'fm', // format
+        's', // signature
+    ];
+
     /**
      * Intervention image manager.
      */
@@ -24,6 +31,13 @@ class Api implements ApiInterface
     protected array $manipulators;
 
     /**
+     * API parameters.
+     *
+     * @var list<string>
+     */
+    protected array $apiParams;
+
+    /**
      * Create API instance.
      *
      * @param ImageManager $imageManager Intervention image manager.
@@ -33,6 +47,7 @@ class Api implements ApiInterface
     {
         $this->setImageManager($imageManager);
         $this->setManipulators($manipulators);
+        $this->setApiParams();
     }
 
     /**
@@ -115,5 +130,33 @@ class Api implements ApiInterface
         $encoded = $encoder->run($image);
 
         return $encoded->toString();
+    }
+
+    /**
+     * Sets the API parameters for all manipulators.
+     *
+     * @return list<string>
+     */
+    public function setApiParams(): array
+    {
+        $params = [];
+
+        array_walk($this->manipulators, function (ManipulatorInterface $manipulator) use (&$params) {
+            foreach ($manipulator->getApiParams() as $param) {
+                $params[] = $param;
+            }
+        });
+
+        return $this->apiParams = array_values(array_unique(array_merge(self::GLOBAL_API_PARAMS, $params)));
+    }
+
+    /**
+     * Retun the list of API params.
+     *
+     * @return list<string>
+     */
+    public function getApiParams(): array
+    {
+        return $this->apiParams;
     }
 }

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -142,9 +142,7 @@ class Api implements ApiInterface
         $this->apiParams = self::GLOBAL_API_PARAMS;
 
         foreach ($this->manipulators as $manipulator) {
-            foreach ($manipulator->getApiParams() as $param) {
-                $this->apiParams[] = $param;
-            }
+            $this->apiParams = array_merge($this->apiParams, $manipulator->getApiParams());
         }
 
         return $this->apiParams = array_values(array_unique($this->apiParams));

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -12,7 +12,7 @@ use League\Glide\Manipulators\ManipulatorInterface;
 class Api implements ApiInterface
 {
     public const GLOBAL_API_PARAMS = [
-        'p', // presets
+        'p', // preset
         'q', // quality
         'fm', // format
         's', // signature
@@ -139,15 +139,15 @@ class Api implements ApiInterface
      */
     public function setApiParams(): array
     {
-        $params = [];
+        $this->apiParams = self::GLOBAL_API_PARAMS;
 
-        array_walk($this->manipulators, function (ManipulatorInterface $manipulator) use (&$params) {
+        foreach ($this->manipulators as $manipulator) {
             foreach ($manipulator->getApiParams() as $param) {
-                $params[] = $param;
+                $this->apiParams[] = $param;
             }
-        });
+        }
 
-        return $this->apiParams = array_values(array_unique(array_merge(self::GLOBAL_API_PARAMS, $params)));
+        return $this->apiParams = array_values(array_unique($this->apiParams));
     }
 
     /**

--- a/src/Api/ApiInterface.php
+++ b/src/Api/ApiInterface.php
@@ -15,4 +15,11 @@ interface ApiInterface
      * @return string Manipulated image binary data.
      */
     public function run(string $source, array $params): string;
+
+    /**
+     * Collection of API parameters.
+     *
+     * @return list<string>
+     */
+    public function getApiParams(): array;
 }

--- a/src/Manipulators/Background.php
+++ b/src/Manipulators/Background.php
@@ -10,6 +10,11 @@ use League\Glide\Manipulators\Helpers\Color;
 
 class Background extends BaseManipulator
 {
+    public function getApiParams(): array
+    {
+        return ['bg'];
+    }
+
     /**
      * Perform background image manipulation.
      *

--- a/src/Manipulators/BaseManipulator.php
+++ b/src/Manipulators/BaseManipulator.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace League\Glide\Manipulators;
 
-use Intervention\Image\Interfaces\ImageInterface;
-
 abstract class BaseManipulator implements ManipulatorInterface
 {
     /**

--- a/src/Manipulators/BaseManipulator.php
+++ b/src/Manipulators/BaseManipulator.php
@@ -36,18 +36,4 @@ abstract class BaseManipulator implements ManipulatorInterface
             ? $this->params[$name]
             : null;
     }
-
-    /**
-     * Get the names of the manipulator API parameters.
-     *
-     * @return list<string>
-     */
-    abstract public function getApiParams(): array;
-
-    /**
-     * Perform the image manipulation.
-     *
-     * @return ImageInterface The manipulated image.
-     */
-    abstract public function run(ImageInterface $image): ImageInterface;
 }

--- a/src/Manipulators/BaseManipulator.php
+++ b/src/Manipulators/BaseManipulator.php
@@ -40,7 +40,7 @@ abstract class BaseManipulator implements ManipulatorInterface
     /**
      * Get the names of the manipulator API parameters.
      *
-     * @rerun list<string>
+     * @return list<string>
      */
     abstract public function getApiParams(): array;
 

--- a/src/Manipulators/BaseManipulator.php
+++ b/src/Manipulators/BaseManipulator.php
@@ -38,6 +38,13 @@ abstract class BaseManipulator implements ManipulatorInterface
     }
 
     /**
+     * Get the names of the manipulator API parameters.
+     *
+     * @rerun list<string>
+     */
+    abstract public function getApiParams(): array;
+
+    /**
      * Perform the image manipulation.
      *
      * @return ImageInterface The manipulated image.

--- a/src/Manipulators/Blur.php
+++ b/src/Manipulators/Blur.php
@@ -8,6 +8,11 @@ use Intervention\Image\Interfaces\ImageInterface;
 
 class Blur extends BaseManipulator
 {
+    public function getApiParams(): array
+    {
+        return ['blur'];
+    }
+
     /**
      * Perform blur image manipulation.
      *

--- a/src/Manipulators/Border.php
+++ b/src/Manipulators/Border.php
@@ -11,6 +11,11 @@ use League\Glide\Manipulators\Helpers\Dimension;
 
 class Border extends BaseManipulator
 {
+    public function getApiParams(): array
+    {
+        return ['border'];
+    }
+
     /**
      * Perform border image manipulation.
      *
@@ -50,8 +55,8 @@ class Border extends BaseManipulator
         $values = explode(',', $border);
 
         $width = $this->getWidth($image, $this->getDpr(), $values[0]);
-        $color = $this->getColor(isset($values[1]) ? $values[1] : 'ffffff');
-        $method = $this->getMethod(isset($values[2]) ? $values[2] : 'overlay');
+        $color = $this->getColor($values[1] ?? 'ffffff');
+        $method = $this->getMethod($values[2] ?? 'overlay');
 
         if (null !== $width) {
             return [$width, $color, $method];

--- a/src/Manipulators/Brightness.php
+++ b/src/Manipulators/Brightness.php
@@ -8,6 +8,11 @@ use Intervention\Image\Interfaces\ImageInterface;
 
 class Brightness extends BaseManipulator
 {
+    public function getApiParams(): array
+    {
+        return ['bri'];
+    }
+
     /**
      * Perform brightness image manipulation.
      *

--- a/src/Manipulators/Contrast.php
+++ b/src/Manipulators/Contrast.php
@@ -8,6 +8,11 @@ use Intervention\Image\Interfaces\ImageInterface;
 
 class Contrast extends BaseManipulator
 {
+    public function getApiParams(): array
+    {
+        return ['con'];
+    }
+
     /**
      * Perform contrast image manipulation.
      *

--- a/src/Manipulators/Crop.php
+++ b/src/Manipulators/Crop.php
@@ -8,6 +8,11 @@ use Intervention\Image\Interfaces\ImageInterface;
 
 class Crop extends BaseManipulator
 {
+    public function getApiParams(): array
+    {
+        return ['crop'];
+    }
+
     /**
      * Perform crop image manipulation.
      *

--- a/src/Manipulators/Filter.php
+++ b/src/Manipulators/Filter.php
@@ -8,6 +8,11 @@ use Intervention\Image\Interfaces\ImageInterface;
 
 class Filter extends BaseManipulator
 {
+    public function getApiParams(): array
+    {
+        return ['filt'];
+    }
+
     /**
      * Perform filter image manipulation.
      *

--- a/src/Manipulators/Flip.php
+++ b/src/Manipulators/Flip.php
@@ -8,6 +8,11 @@ use Intervention\Image\Interfaces\ImageInterface;
 
 class Flip extends BaseManipulator
 {
+    public function getApiParams(): array
+    {
+        return ['flip'];
+    }
+
     /**
      * Perform flip image manipulation.
      *

--- a/src/Manipulators/Gamma.php
+++ b/src/Manipulators/Gamma.php
@@ -8,6 +8,11 @@ use Intervention\Image\Interfaces\ImageInterface;
 
 class Gamma extends BaseManipulator
 {
+    public function getApiParams(): array
+    {
+        return ['gam'];
+    }
+
     /**
      * Perform gamma image manipulation.
      *

--- a/src/Manipulators/ManipulatorInterface.php
+++ b/src/Manipulators/ManipulatorInterface.php
@@ -23,6 +23,13 @@ interface ManipulatorInterface
     public function getParam(string $name): mixed;
 
     /**
+     * Get the names of the manipulator API parameters.
+     *
+     * @rerun list<string>
+     */
+    public function getApiParams(): array;
+
+    /**
      * Perform the image manipulation.
      *
      * @param ImageInterface $image The source image.

--- a/src/Manipulators/ManipulatorInterface.php
+++ b/src/Manipulators/ManipulatorInterface.php
@@ -25,7 +25,7 @@ interface ManipulatorInterface
     /**
      * Get the names of the manipulator API parameters.
      *
-     * @rerun list<string>
+     * @return list<string>
      */
     public function getApiParams(): array;
 

--- a/src/Manipulators/Orientation.php
+++ b/src/Manipulators/Orientation.php
@@ -8,6 +8,11 @@ use Intervention\Image\Interfaces\ImageInterface;
 
 class Orientation extends BaseManipulator
 {
+    public function getApiParams(): array
+    {
+        return ['or'];
+    }
+
     /**
      * Perform orientation image manipulation.
      *

--- a/src/Manipulators/Pixelate.php
+++ b/src/Manipulators/Pixelate.php
@@ -8,6 +8,11 @@ use Intervention\Image\Interfaces\ImageInterface;
 
 class Pixelate extends BaseManipulator
 {
+    public function getApiParams(): array
+    {
+        return ['pixel'];
+    }
+
     /**
      * Perform pixelate image manipulation.
      *

--- a/src/Manipulators/Sharpen.php
+++ b/src/Manipulators/Sharpen.php
@@ -8,6 +8,11 @@ use Intervention\Image\Interfaces\ImageInterface;
 
 class Sharpen extends BaseManipulator
 {
+    public function getApiParams(): array
+    {
+        return ['sharp'];
+    }
+
     /**
      * Perform sharpen image manipulation.
      *

--- a/src/Manipulators/Size.php
+++ b/src/Manipulators/Size.php
@@ -24,6 +24,11 @@ class Size extends BaseManipulator
         $this->maxImageSize = $maxImageSize;
     }
 
+    public function getApiParams(): array
+    {
+        return ['w', 'f', 'fit', 'dpr'];
+    }
+
     /**
      * Set the maximum image size.
      *
@@ -427,7 +432,7 @@ class Size extends BaseManipulator
         }
 
         if (preg_match('/^crop-([\d]{1,3})-([\d]{1,3})(?:-([\d]{1,3}(?:\.\d+)?))*$/', $fit, $matches)) {
-            $matches[3] = isset($matches[3]) ? $matches[3] : 1;
+            $matches[3] = $matches[3] ?? 1;
 
             if ($matches[1] > 100 || $matches[2] > 100 || $matches[3] > 100) {
                 return [50, 50, 1.0];

--- a/src/Manipulators/Watermark.php
+++ b/src/Manipulators/Watermark.php
@@ -33,6 +33,11 @@ class Watermark extends BaseManipulator
         $this->setWatermarksPathPrefix($watermarksPathPrefix);
     }
 
+    public function getApiParams(): array
+    {
+        return ['mark', 'markw', 'markh', 'markx', 'marky', 'markpad', 'markfit', 'markpos', 'markalpha', 'dpr'];
+    }
+
     /**
      * Set the watermarks file system.
      *

--- a/src/Server.php
+++ b/src/Server.php
@@ -366,8 +366,7 @@ class Server
         }
 
         if ($this->cacheWithFileExtensions) {
-            /** @psalm-suppress PossiblyUndefinedArrayOffset */
-            $ext = isset($params['fm']) ? $params['fm'] : pathinfo($path, PATHINFO_EXTENSION);
+            $ext = $params['fm'] ?? pathinfo($path, PATHINFO_EXTENSION);
             $ext = 'pjpg' === $ext ? 'jpg' : $ext;
             $cachedPath .= '.'.$ext;
         }
@@ -481,23 +480,23 @@ class Server
     /**
      * Get all image manipulations params, including defaults and presets.
      *
-     * @param array $params Image manipulation params.
+     * @param array<string, string|int> $params Image manipulation params.
      *
-     * @return array All image manipulation params.
+     * @return array<string, string|int> All image manipulation params.
      */
     public function getAllParams(array $params): array
     {
         $all = $this->defaults;
 
         if (isset($params['p'])) {
-            foreach (explode(',', $params['p']) as $preset) {
+            foreach (explode(',', (string) $params['p']) as $preset) {
                 if (isset($this->presets[$preset])) {
                     $all = array_merge($all, $this->presets[$preset]);
                 }
             }
         }
 
-        return array_merge($all, $params);
+        return array_filter(array_merge($all, $params), fn ($key) => in_array($key, $this->api->getApiParams(), true), ARRAY_FILTER_USE_KEY);
     }
 
     /**

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -60,6 +60,19 @@ class ApiTest extends TestCase
         $this->assertEquals([], $this->api->getManipulators());
     }
 
+    public function testGetApiParams(): void
+    {
+        $manipulator1 = \Mockery::mock(ManipulatorInterface::class, function ($mock) {
+            $mock->shouldReceive('getApiParams')->andReturn(['foo', 'bar']);
+        });
+        $manipulator2 = \Mockery::mock(ManipulatorInterface::class, function ($mock) {
+            $mock->shouldReceive('getApiParams')->andReturn(['foo', 'baz']);
+        });
+
+        $api = new Api(ImageManager::gd(), [$manipulator1, $manipulator2]);
+        $this->assertEquals(array_merge(Api::GLOBAL_API_PARAMS, ['foo', 'bar', 'baz']), $api->getApiParams());
+    }
+
     public function testRun()
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
@@ -77,6 +90,7 @@ class ApiTest extends TestCase
         $manipulator = \Mockery::mock(ManipulatorInterface::class, function ($mock) use ($image) {
             $mock->shouldReceive('setParams')->with([]);
             $mock->shouldReceive('run')->andReturn($image);
+            $mock->shouldReceive('getApiParams')->andReturn(['p', 'q', 'fm', 's']);
         });
 
         $api = new Api($manager, [$manipulator]);

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -4,33 +4,31 @@ declare(strict_types=1);
 
 namespace League\Glide;
 
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\UnableToCheckFileExistence;
+use League\Flysystem\UnableToReadFile;
+use League\Flysystem\UnableToWriteFile;
+use League\Glide\Api\ApiInterface;
 use League\Glide\Filesystem\FileNotFoundException;
 use League\Glide\Filesystem\FilesystemException;
+use League\Glide\Responses\ResponseFactoryInterface;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 
 class ServerTest extends TestCase
 {
-    private $server;
+    private Server $server;
 
     public function setUp(): void
     {
-        $response = \Mockery::mock('Psr\Http\Message\ResponseInterface');
-
-        $responseFactory = \Mockery::mock('League\Glide\Responses\ResponseFactoryInterface');
-        $responseFactory
-            ->shouldReceive('create')
-            ->andReturn($response)
-            ->shouldReceive('send')
-            ->andReturnUsing(function () {
-                echo 'content';
-            });
-
         $this->server = new Server(
-            \Mockery::mock('League\Flysystem\FilesystemOperator'),
-            \Mockery::mock('League\Flysystem\FilesystemOperator'),
-            \Mockery::mock('League\Glide\Api\ApiInterface'),
-            $responseFactory
+            \Mockery::mock(FilesystemOperator::class),
+            \Mockery::mock(FilesystemOperator::class),
+            \Mockery::mock(ApiInterface::class, function ($mock) {
+                $mock->shouldReceive('run')->andReturn('content');
+                $mock->shouldReceive('getApiParams')->andReturn(['p', 'q', 'fm', 's', 'w', 'h', 'fit', 'crop', 'dpr']);
+            })
         );
     }
 
@@ -39,39 +37,39 @@ class ServerTest extends TestCase
         \Mockery::close();
     }
 
-    public function testCreateInstance()
+    public function testCreateInstance(): void
     {
-        $this->assertInstanceOf('League\Glide\Server', $this->server);
+        $this->assertInstanceOf(Server::class, $this->server);
     }
 
-    public function testSetSource()
+    public function testSetSource(): void
     {
-        $this->server->setSource(\Mockery::mock('League\Flysystem\FilesystemOperator'));
-        $this->assertInstanceOf('League\Flysystem\FilesystemOperator', $this->server->getSource());
+        $this->server->setSource(\Mockery::mock(FilesystemOperator::class));
+        $this->assertInstanceOf(FilesystemOperator::class, $this->server->getSource());
     }
 
-    public function testGetSource()
+    public function testGetSource(): void
     {
-        $this->assertInstanceOf('League\Flysystem\FilesystemOperator', $this->server->getSource());
+        $this->assertInstanceOf(FilesystemOperator::class, $this->server->getSource());
     }
 
-    public function testSetSourcePathPrefix()
+    public function testSetSourcePathPrefix(): void
     {
         $this->server->setSourcePathPrefix('img/');
         $this->assertEquals('img', $this->server->getSourcePathPrefix());
     }
 
-    public function testGetSourcePathPrefix()
+    public function testGetSourcePathPrefix(): void
     {
         $this->assertEquals('', $this->server->getSourcePathPrefix());
     }
 
-    public function testGetSourcePath()
+    public function testGetSourcePath(): void
     {
         $this->assertEquals('image.jpg', $this->server->getSourcePath('image.jpg'));
     }
 
-    public function testGetSourcePathWithBaseUrl()
+    public function testGetSourcePathWithBaseUrl(): void
     {
         $this->server->setBaseUrl('img/');
         $this->assertEquals('image.jpg', $this->server->getSourcePath('img/image.jpg'));
@@ -81,13 +79,13 @@ class ServerTest extends TestCase
         $this->assertEquals('imgur.jpg', $this->server->getSourcePath('imgur.jpg'));
     }
 
-    public function testGetSourcePathWithPrefix()
+    public function testGetSourcePathWithPrefix(): void
     {
         $this->server->setSourcePathPrefix('img/');
         $this->assertEquals('img/image.jpg', $this->server->getSourcePath('image.jpg'));
     }
 
-    public function testGetSourcePathWithMissingPath()
+    public function testGetSourcePathWithMissingPath(): void
     {
         $this->expectException(FileNotFoundException::class);
         $this->expectExceptionMessage('Image path missing.');
@@ -95,77 +93,77 @@ class ServerTest extends TestCase
         $this->server->getSourcePath('');
     }
 
-    public function testGetSourcePathWithEncodedEntities()
+    public function testGetSourcePathWithEncodedEntities(): void
     {
         $this->assertEquals('an image.jpg', $this->server->getSourcePath('an%20image.jpg'));
     }
 
-    public function testSourceFileExists()
+    public function testSourceFileExists(): void
     {
-        $this->server->setSource(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+        $this->server->setSource(\Mockery::mock(FilesystemOperator::class, function ($mock) {
             $mock->shouldReceive('fileExists')->with('image.jpg')->andReturn(true)->once();
         }));
 
         $this->assertTrue($this->server->sourceFileExists('image.jpg'));
     }
 
-    public function testSetBaseUrl()
+    public function testSetBaseUrl(): void
     {
         $this->server->setBaseUrl('img/');
         $this->assertEquals('img', $this->server->getBaseUrl());
     }
 
-    public function testGetBaseUrl()
+    public function testGetBaseUrl(): void
     {
         $this->assertEquals('', $this->server->getBaseUrl());
     }
 
-    public function testSetCache()
+    public function testSetCache(): void
     {
-        $this->server->setCache(\Mockery::mock('League\Flysystem\FilesystemOperator'));
-        $this->assertInstanceOf('League\Flysystem\FilesystemOperator', $this->server->getCache());
+        $this->server->setCache(\Mockery::mock(FilesystemOperator::class));
+        $this->assertInstanceOf(FilesystemOperator::class, $this->server->getCache());
     }
 
-    public function testGetCache()
+    public function testGetCache(): void
     {
-        $this->assertInstanceOf('League\Flysystem\FilesystemOperator', $this->server->getCache());
+        $this->assertInstanceOf(FilesystemOperator::class, $this->server->getCache());
     }
 
-    public function testSetCachePathPrefix()
+    public function testSetCachePathPrefix(): void
     {
         $this->server->setCachePathPrefix('img/');
         $this->assertEquals('img', $this->server->getCachePathPrefix());
     }
 
-    public function testGetCachePathPrefix()
+    public function testGetCachePathPrefix(): void
     {
         $this->assertEquals('', $this->server->getCachePathPrefix());
     }
 
-    public function testSetInvalidTempDir()
+    public function testSetInvalidTempDir(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->server->setTempDir('/invalid/path');
     }
 
-    public function testSetGetTempDir()
+    public function testSetGetTempDir(): void
     {
         $this->server->setTempDir(__DIR__);
         $this->assertSame(__DIR__.DIRECTORY_SEPARATOR, $this->server->getTempDir());
     }
 
-    public function testSetCachePathCallable()
+    public function testSetCachePathCallable(): void
     {
         $this->server->setCachePathCallable(null);
         $this->assertEquals(null, $this->server->getCachePathCallable());
     }
 
-    public function testGetCachePathCallable()
+    public function testGetCachePathCallable(): void
     {
         $this->assertEquals(null, $this->server->getCachePathCallable());
     }
 
-    public function testCachePathCallableIsCalledOnGetCachePath()
+    public function testCachePathCallableIsCalledOnGetCachePath(): void
     {
         $expected = 'TEST';
         $callable = function () use ($expected) {
@@ -177,11 +175,12 @@ class ServerTest extends TestCase
         self::assertEquals($expected, $this->server->getCachePath(''));
     }
 
-    public function testSetCachePathCallableIsBoundClosure()
+    public function testSetCachePathCallableIsBoundClosure(): void
     {
         $server = $this->server;
         $phpUnit = $this;
-        $this->server->setCachePathCallable(function () use ($phpUnit, $server) {
+
+        $this->server->setCachePathCallable(function () use ($server, $phpUnit) {
             $phpUnit::assertEquals($server, $this);
 
             return '';
@@ -190,7 +189,7 @@ class ServerTest extends TestCase
         $this->server->getCachePath('');
     }
 
-    public function testSetCachePathCallableArgumentsAreSameAsGetCachePath()
+    public function testSetCachePathCallableArgumentsAreSameAsGetCachePath(): void
     {
         $phpUnit = $this;
         $pathArgument = 'TEST';
@@ -209,31 +208,31 @@ class ServerTest extends TestCase
         $this->server->getCachePath($pathArgument, $optionsArgument);
     }
 
-    public function testSetGroupCacheInFolders()
+    public function testSetGroupCacheInFolders(): void
     {
         $this->server->setGroupCacheInFolders(false);
 
         $this->assertFalse($this->server->getGroupCacheInFolders());
     }
 
-    public function testGetGroupCacheInFolders()
+    public function testGetGroupCacheInFolders(): void
     {
         $this->assertTrue($this->server->getGroupCacheInFolders());
     }
 
-    public function testSetCacheWithFileExtensions()
+    public function testSetCacheWithFileExtensions(): void
     {
         $this->server->setCacheWithFileExtensions(true);
 
         $this->assertTrue($this->server->getCacheWithFileExtensions());
     }
 
-    public function testGetCacheWithFileExtensions()
+    public function testGetCacheWithFileExtensions(): void
     {
         $this->assertFalse($this->server->getCacheWithFileExtensions());
     }
 
-    public function testGetCachePath()
+    public function testGetCachePath(): void
     {
         $this->assertEquals(
             'image.jpg/382a458ecb704818',
@@ -241,7 +240,7 @@ class ServerTest extends TestCase
         );
     }
 
-    public function testGetCachePathWithNoFolderGrouping()
+    public function testGetCachePathWithNoFolderGrouping(): void
     {
         $this->server->setGroupCacheInFolders(false);
 
@@ -251,51 +250,51 @@ class ServerTest extends TestCase
         );
     }
 
-    public function testGetCachePathWithPrefix()
+    public function testGetCachePathWithPrefix(): void
     {
         $this->server->setCachePathPrefix('img/');
         $this->assertEquals('img/image.jpg/a2c14b0b5cf0e5a5', $this->server->getCachePath('image.jpg', []));
     }
 
-    public function testGetCachePathWithSourcePrefix()
+    public function testGetCachePathWithSourcePrefix(): void
     {
         $this->server->setSourcePathPrefix('img/');
         $this->assertEquals('image.jpg/a2c14b0b5cf0e5a5', $this->server->getCachePath('image.jpg', []));
     }
 
-    public function testGetCachePathWithExtension()
+    public function testGetCachePathWithExtension(): void
     {
         $this->server->setCacheWithFileExtensions(true);
         $this->assertEquals('image.jpg/a2c14b0b5cf0e5a5.jpg', $this->server->getCachePath('image.jpg', []));
     }
 
-    public function testGetCachePathWithExtensionAndFmParam()
+    public function testGetCachePathWithExtensionAndFmParam(): void
     {
         $this->server->setCacheWithFileExtensions(true);
         $this->assertEquals('image.jpg/1521d6d426c257b2.gif', $this->server->getCachePath('image.jpg', ['fm' => 'gif']));
     }
 
-    public function testGetCachePathWithExtensionAndPjpgFmParam()
+    public function testGetCachePathWithExtensionAndPjpgFmParam(): void
     {
         $this->server->setCacheWithFileExtensions(true);
         $this->assertEquals('image.jpg/58b79a7735b61b0d.jpg', $this->server->getCachePath('image.jpg', ['fm' => 'pjpg']));
     }
 
-    public function testGetCachePathWithExtensionAndFmFromDefaults()
+    public function testGetCachePathWithExtensionAndFmFromDefaults(): void
     {
         $this->server->setCacheWithFileExtensions(true);
         $this->server->setDefaults(['fm' => 'gif']);
         $this->assertEquals('image.jpg/1521d6d426c257b2.gif', $this->server->getCachePath('image.jpg', []));
     }
 
-    public function testGetCachePathWithExtensionAndPjpgFmFromDefaults()
+    public function testGetCachePathWithExtensionAndPjpgFmFromDefaults(): void
     {
         $this->server->setCacheWithFileExtensions(true);
         $this->server->setDefaults(['fm' => 'pjpg']);
         $this->assertEquals('image.jpg/58b79a7735b61b0d.jpg', $this->server->getCachePath('image.jpg', []));
     }
 
-    public function testGetCachePathWithExtensionAndFmFromPreset()
+    public function testGetCachePathWithExtensionAndFmFromPreset(): void
     {
         $this->server->setCacheWithFileExtensions(true);
 
@@ -306,7 +305,7 @@ class ServerTest extends TestCase
         $this->assertEquals('image.jpg/1521d6d426c257b2.gif', $this->server->getCachePath('image.jpg', ['p' => 'gif']));
     }
 
-    public function testGetCachePathWithExtensionAndPjpgFmFromPreset()
+    public function testGetCachePathWithExtensionAndPjpgFmFromPreset(): void
     {
         $this->server->setCacheWithFileExtensions(true);
 
@@ -317,25 +316,25 @@ class ServerTest extends TestCase
         $this->assertEquals('image.jpg/58b79a7735b61b0d.jpg', $this->server->getCachePath('image.jpg', ['p' => 'pjpg']));
     }
 
-    public function testCacheFileExists()
+    public function testCacheFileExists(): void
     {
-        $this->server->setCache(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+        $this->server->setCache(\Mockery::mock(FilesystemOperator::class, function ($mock) {
             $mock->shouldReceive('fileExists')->with('image.jpg/a2c14b0b5cf0e5a5')->andReturn(true)->once();
         }));
 
         $this->assertTrue($this->server->cacheFileExists('image.jpg', []));
     }
 
-    public function testDeleteCache()
+    public function testDeleteCache(): void
     {
-        $this->server->setCache(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+        $this->server->setCache(\Mockery::mock(FilesystemOperator::class, function ($mock) {
             $mock->shouldReceive('deleteDirectory')->with('image.jpg')->andReturn(true)->once();
         }));
 
         $this->assertTrue($this->server->deleteCache('image.jpg', []));
     }
 
-    public function testDeleteCacheWithGroupCacheInFoldersDisabled()
+    public function testDeleteCacheWithGroupCacheInFoldersDisabled(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Deleting cached image manipulations is not possible when grouping cache into folders is disabled.');
@@ -345,19 +344,19 @@ class ServerTest extends TestCase
         $this->server->deleteCache('image.jpg', []);
     }
 
-    public function testSetApi()
+    public function testSetApi(): void
     {
-        $api = \Mockery::mock('League\Glide\Api\ApiInterface');
+        $api = \Mockery::mock(ApiInterface::class);
         $this->server->setApi($api);
-        $this->assertInstanceOf('League\Glide\Api\ApiInterface', $this->server->getApi());
+        $this->assertInstanceOf(ApiInterface::class, $this->server->getApi());
     }
 
-    public function testGetApi()
+    public function testGetApi(): void
     {
-        $this->assertInstanceOf('League\Glide\Api\ApiInterface', $this->server->getApi());
+        $this->assertInstanceOf(ApiInterface::class, $this->server->getApi());
     }
 
-    public function testSetDefaults()
+    public function testSetDefaults(): void
     {
         $defaults = [
             'fm' => 'jpg',
@@ -368,12 +367,12 @@ class ServerTest extends TestCase
         $this->assertSame($defaults, $this->server->getDefaults());
     }
 
-    public function testGetDefaults()
+    public function testGetDefaults(): void
     {
         $this->testSetDefaults();
     }
 
-    public function testSetPresets()
+    public function testSetPresets(): void
     {
         $presets = [
             'small' => [
@@ -388,12 +387,12 @@ class ServerTest extends TestCase
         $this->assertSame($presets, $this->server->getPresets());
     }
 
-    public function testGetPresets()
+    public function testGetPresets(): void
     {
         $this->testSetPresets();
     }
 
-    public function testGetAllParams()
+    public function testGetAllParams(): void
     {
         $this->server->setDefaults([
             'fm' => 'jpg',
@@ -410,6 +409,7 @@ class ServerTest extends TestCase
         $all_params = $this->server->getAllParams([
             'w' => '100',
             'p' => 'small',
+            'invalid' => '1',
         ]);
 
         $this->assertSame([
@@ -421,38 +421,38 @@ class ServerTest extends TestCase
         ], $all_params);
     }
 
-    public function testSetResponseFactory()
+    public function testSetResponseFactory(): void
     {
-        $this->server->setResponseFactory(\Mockery::mock('League\Glide\Responses\ResponseFactoryInterface'));
+        $this->server->setResponseFactory(\Mockery::mock(ResponseFactoryInterface::class));
 
         $this->assertInstanceOf(
-            'League\Glide\Responses\ResponseFactoryInterface',
+            ResponseFactoryInterface::class,
             $this->server->getResponseFactory()
         );
     }
 
-    public function testGetResponseFactory()
+    public function testGetResponseFactory(): void
     {
         $this->testSetResponseFactory();
     }
 
-    public function testGetImageResponse()
+    public function testGetImageResponse(): void
     {
-        $this->server->setResponseFactory(\Mockery::mock('League\Glide\Responses\ResponseFactoryInterface', function ($mock) {
-            $mock->shouldReceive('create')->andReturn(\Mockery::mock('Psr\Http\Message\ResponseInterface'));
+        $this->server->setResponseFactory(\Mockery::mock(ResponseFactoryInterface::class, function ($mock) {
+            $mock->shouldReceive('create')->andReturn(\Mockery::mock(ResponseInterface::class));
         }));
 
-        $this->server->setCache(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+        $this->server->setCache(\Mockery::mock(FilesystemOperator::class, function ($mock) {
             $mock->shouldReceive('fileExists')->andReturn(true);
         }));
 
         $this->assertInstanceOf(
-            'Psr\Http\Message\ResponseInterface',
+            ResponseInterface::class,
             $this->server->getImageResponse('image.jpg', [])
         );
     }
 
-    public function testGetImageResponseWithoutResponseFactory()
+    public function testGetImageResponseWithoutResponseFactory(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to get image response, no response factory defined.');
@@ -460,9 +460,9 @@ class ServerTest extends TestCase
         $this->server->getImageResponse('image.jpg', []);
     }
 
-    public function testGetImageAsBase64()
+    public function testGetImageAsBase64(): void
     {
-        $this->server->setCache(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+        $this->server->setCache(\Mockery::mock(FilesystemOperator::class, function ($mock) {
             $mock->shouldReceive('fileExists')->andReturn(true);
             $mock->shouldReceive('mimeType')->andReturn('image/jpeg');
             $mock->shouldReceive('read')->andReturn('content')->once();
@@ -479,7 +479,7 @@ class ServerTest extends TestCase
         $this->expectException(FilesystemException::class);
         $this->expectExceptionMessage('Could not read the image `image.jpg/a2c14b0b5cf0e5a5`.');
 
-        $this->server->setCache(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+        $this->server->setCache(\Mockery::mock(FilesystemOperator::class, function ($mock) {
             $mock->shouldReceive('fileExists')->andReturn(true);
             $mock->shouldReceive('mimeType')->andReturn('image/jpeg');
             $mock->shouldReceive('read')->andThrow('League\Flysystem\UnableToReadFile')->once();
@@ -491,7 +491,7 @@ class ServerTest extends TestCase
     #[RunInSeparateProcess]
     public function testOutputImage()
     {
-        $this->server->setCache(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+        $this->server->setCache(\Mockery::mock(FilesystemOperator::class, function ($mock) {
             $mock->shouldReceive('fileExists')->andReturn(true);
             $mock->shouldReceive('mimeType')->andReturn('image/jpeg');
             $mock->shouldReceive('fileSize')->andReturn(0);
@@ -511,17 +511,17 @@ class ServerTest extends TestCase
 
     public function testMakeImageFromSource()
     {
-        $this->server->setSource(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+        $this->server->setSource(\Mockery::mock(FilesystemOperator::class, function ($mock) {
             $mock->shouldReceive('fileExists')->andReturn(true)->once();
             $mock->shouldReceive('read')->andReturn('content')->once();
         }));
 
-        $this->server->setCache(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+        $this->server->setCache(\Mockery::mock(FilesystemOperator::class, function ($mock) {
             $mock->shouldReceive('fileExists')->andReturn(false)->once();
             $mock->shouldReceive('write')->withArgs(['image.jpg/a2c14b0b5cf0e5a5', 'content'])->once();
         }));
 
-        $this->server->setApi(\Mockery::mock('League\Glide\Api\ApiInterface', function ($mock) {
+        $this->server->setApi(\Mockery::mock(ApiInterface::class, function ($mock) {
             $mock->shouldReceive('run')->withArgs(['content', []])->andReturn('content')->once();
         }));
 
@@ -533,18 +533,18 @@ class ServerTest extends TestCase
 
     public function testMakeImageFromSourceWithCustomTmpDir()
     {
-        $this->server->setSource(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+        $this->server->setSource(\Mockery::mock(FilesystemOperator::class, function ($mock) {
             $mock->shouldReceive('fileExists')->andReturn(true)->once();
             $mock->shouldReceive('read')->andReturn('content')->once();
         }));
 
-        $this->server->setCache(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+        $this->server->setCache(\Mockery::mock(FilesystemOperator::class, function ($mock) {
             $mock->shouldReceive('fileExists')->andReturn(false)->once();
             $mock->shouldReceive('write')->with('image.jpg/a2c14b0b5cf0e5a5', 'content')->once();
         }));
 
         $this->server->setTempDir(__DIR__);
-        $this->server->setApi(\Mockery::mock('League\Glide\Api\ApiInterface', function ($mock) {
+        $this->server->setApi(\Mockery::mock(ApiInterface::class, function ($mock) {
             $mock->shouldReceive('run')->with('content', [])->andReturn('content')->once();
         }));
 
@@ -556,7 +556,7 @@ class ServerTest extends TestCase
 
     public function testMakeImageFromCache()
     {
-        $this->server->setCache(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+        $this->server->setCache(\Mockery::mock(FilesystemOperator::class, function ($mock) {
             $mock->shouldReceive('fileExists')->andReturn(true);
         }));
 
@@ -571,50 +571,50 @@ class ServerTest extends TestCase
         $this->expectException(FileNotFoundException::class);
         $this->expectExceptionMessage('Could not find the image `image.jpg`.');
 
-        $this->server->setSource(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+        $this->server->setSource(\Mockery::mock(FilesystemOperator::class, function ($mock) {
             $mock->shouldReceive('fileExists')->andReturn(false)->once();
         }));
 
-        $this->server->setCache(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+        $this->server->setCache(\Mockery::mock(FilesystemOperator::class, function ($mock) {
             $mock->shouldReceive('fileExists')->andReturn(false)->once();
         }));
 
         $this->server->makeImage('image.jpg', []);
     }
 
-    public function testMakeImageWithUnreadableSource()
+    public function testMakeImageWithUnreadableSource(): void
     {
         $this->expectException(FilesystemException::class);
         $this->expectExceptionMessage('Could not read the image `image.jpg`.');
 
-        $this->server->setSource(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+        $this->server->setSource(\Mockery::mock(FilesystemOperator::class, function ($mock) {
             $mock->shouldReceive('fileExists')->andReturn(true)->once();
-            $mock->shouldReceive('read')->andThrow('League\Flysystem\UnableToReadFile')->once();
+            $mock->shouldReceive('read')->andThrow(UnableToReadFile::class)->once();
         }));
 
-        $this->server->setCache(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
-            $mock->shouldReceive('fileExists')->andThrow('League\Flysystem\UnableToCheckFileExistence')->once();
+        $this->server->setCache(\Mockery::mock(FilesystemOperator::class, function ($mock) {
+            $mock->shouldReceive('fileExists')->andThrow(UnableToCheckFileExistence::class)->once();
         }));
 
         $this->server->makeImage('image.jpg', []);
     }
 
-    public function testMakeImageWithUnwritableCache()
+    public function testMakeImageWithUnwritableCache(): void
     {
         $this->expectException(FilesystemException::class);
         $this->expectExceptionMessage('Could not write the image `image.jpg/a2c14b0b5cf0e5a5`.');
 
-        $this->server->setSource(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
+        $this->server->setSource(\Mockery::mock(FilesystemOperator::class, function ($mock) {
             $mock->shouldReceive('fileExists')->andReturn(true)->once();
             $mock->shouldReceive('read')->andReturn('content')->once();
         }));
 
-        $this->server->setCache(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($mock) {
-            $mock->shouldReceive('fileExists')->andThrow('League\Flysystem\UnableToCheckFileExistence')->once();
-            $mock->shouldReceive('write')->andThrow('League\Flysystem\UnableToWriteFile')->once();
+        $this->server->setCache(\Mockery::mock(FilesystemOperator::class, function ($mock) {
+            $mock->shouldReceive('fileExists')->andThrow(UnableToCheckFileExistence::class)->once();
+            $mock->shouldReceive('write')->andThrow(UnableToWriteFile::class)->once();
         }));
 
-        $this->server->setApi(\Mockery::mock('League\Glide\Api\ApiInterface', function ($mock) {
+        $this->server->setApi(\Mockery::mock(ApiInterface::class, function ($mock) {
             $mock->shouldReceive('run')->andReturn('content')->once();
         }));
 

--- a/tests/Signatures/SignatureTest.php
+++ b/tests/Signatures/SignatureTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class SignatureTest extends TestCase
 {
-    private $httpSignature;
+    private Signature $httpSignature;
 
     public function setUp(): void
     {


### PR DESCRIPTION
* resolves #412 

- Added new tests to make sure only valid parameters are used
- New interface method for each manipulator to know the API parameters used
- no BC break