### PR TITLE
Ensure original type is preserved when `fm` is not specified.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "intervention/image": "^3.6",
+        "intervention/image": "^3.9.1",
         "league/flysystem": "^3.0",
         "psr/http-message": "^1.0|^2.0"
     },

--- a/src/Api/Encoder.php
+++ b/src/Api/Encoder.php
@@ -6,6 +6,7 @@ namespace League\Glide\Api;
 
 use Intervention\Image\Interfaces\EncodedImageInterface;
 use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\MediaType;
 
 /**
  * Encoder Api class to convert a given image to a specific format.
@@ -102,13 +103,18 @@ class Encoder
     public function getFormat(ImageInterface $image): string
     {
         $fm = (string) $this->getParam('fm');
-
-        if ($fm && array_key_exists($fm, static::supportedFormats())) {
-            return $fm;
+        if ($fm) {
+            return array_key_exists($fm, static::supportedFormats()) ? $fm : 'jpg';
         }
 
-        /** @psalm-suppress RiskyTruthyFalsyComparison */
-        return array_search($image->origin()->mediaType(), static::supportedFormats(), true) ?: 'jpg';
+        $mediaType = MediaType::tryFrom($image->origin()->mediaType());
+        if (null === $mediaType) {
+            return 'jpg';
+        }
+
+        $fm = $mediaType->format()->fileExtension()->value;
+
+        return array_key_exists($fm, static::supportedFormats()) ? $fm : 'jpg';
     }
 
     /**

--- a/tests/Api/EncoderTest.php
+++ b/tests/Api/EncoderTest.php
@@ -107,46 +107,40 @@ class EncoderTest extends TestCase
 
     public function testGetFormat(): void
     {
-        /**
-         * @psalm-suppress MissingClosureParamType
-         */
-        $image = \Mockery::mock(ImageInterface::class, function ($mock) {
-            /*
-             * @var Mock $mock
-             */
-            $this->assertMediaType($mock, 'image/jpeg')->once();
-            $this->assertMediaType($mock, 'image/png')->once();
-            $this->assertMediaType($mock, 'image/gif')->once();
-            $this->assertMediaType($mock, 'image/bmp')->once();
-            $this->assertMediaType($mock, 'image/jpeg')->twice();
+        $this->assertSame('jpg', $this->encoder->setParams(['fm' => 'jpg'])->getFormat($this->getImageByMimeType('image/jpeg')));
+        $this->assertSame('png', $this->encoder->setParams(['fm' => 'png'])->getFormat($this->getImageByMimeType('image/png')));
+        $this->assertSame('gif', $this->encoder->setParams(['fm' => 'gif'])->getFormat($this->getImageByMimeType('image/gif')));
 
-            if (function_exists('imagecreatefromwebp')) {
-                $this->assertMediaType($mock, 'image/webp')->once();
-            }
+        // Make sure 'fm' parameter takes precedence
+        $this->assertSame('png', $this->encoder->setParams(['fm' => 'png'])->getFormat($this->getImageByMimeType('image/jpeg')));
+        $this->assertSame('gif', $this->encoder->setParams(['fm' => 'gif'])->getFormat($this->getImageByMimeType('image/jpeg')));
+        $this->assertSame('pjpg', $this->encoder->setParams(['fm' => 'pjpg'])->getFormat($this->getImageByMimeType('image/jpeg')));
 
-            if (function_exists('imagecreatefromavif')) {
-                $this->assertMediaType($mock, 'image/avif')->once();
-            }
-        });
+        // Make sure we keep the current format if no format is provided
+        $this->assertSame('jpg', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/jpeg')));
+        $this->assertSame('png', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/png')));
+        $this->assertSame('gif', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/gif')));
 
-        $this->assertSame('jpg', $this->encoder->setParams(['fm' => 'jpg'])->getFormat($image));
-        $this->assertSame('png', $this->encoder->setParams(['fm' => 'png'])->getFormat($image));
-        $this->assertSame('gif', $this->encoder->setParams(['fm' => 'gif'])->getFormat($image));
-        $this->assertSame('jpg', $this->encoder->setParams(['fm' => null])->getFormat($image));
-        $this->assertSame('png', $this->encoder->setParams(['fm' => null])->getFormat($image));
-        $this->assertSame('gif', $this->encoder->setParams(['fm' => null])->getFormat($image));
-        $this->assertSame('jpg', $this->encoder->setParams(['fm' => null])->getFormat($image));
-
-        $this->assertSame('jpg', $this->encoder->setParams(['fm' => ''])->getFormat($image));
-        $this->assertSame('jpg', $this->encoder->setParams(['fm' => 'invalid'])->getFormat($image));
+        $this->assertSame('jpg', $this->encoder->setParams(['fm' => ''])->getFormat($this->getImageByMimeType('image/jpeg')));
+        $this->assertSame('png', $this->encoder->setParams(['fm' => ''])->getFormat($this->getImageByMimeType('image/png')));
+        $this->assertSame('jpg', $this->encoder->setParams(['fm' => 'invalid'])->getFormat($this->getImageByMimeType('image/png')));
 
         if (function_exists('imagecreatefromwebp')) {
-            $this->assertSame('webp', $this->encoder->setParams(['fm' => null])->getFormat($image));
+            $this->assertSame('webp', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/webp')));
+            $this->assertSame('webp', $this->encoder->setParams(['fm' => 'webp'])->getFormat($this->getImageByMimeType('image/jpeg')));
         }
 
         if (function_exists('imagecreatefromavif')) {
-            $this->assertSame('avif', $this->encoder->setParams(['fm' => null])->getFormat($image));
+            $this->assertSame('avif', $this->encoder->setParams(['fm' => null])->getFormat($this->getImageByMimeType('image/avif')));
+            $this->assertSame('avif', $this->encoder->setParams(['fm' => 'avif'])->getFormat($this->getImageByMimeType('image/jpeg')));
         }
+    }
+
+    protected function getImageByMimeType(string $mimeType): ImageInterface
+    {
+        return \Mockery::mock(ImageInterface::class, function ($mock) use ($mimeType) {
+            $this->assertMediaType($mock, $mimeType);
+        });
     }
 
     public function testGetQuality(): void


### PR DESCRIPTION
Earlier, if `fm` was not specified then an image with mime-type "image/x-webp" would get encoded as jpg instead of webp, since the mime type is not include in the Encoder::supportedFormats() list.