### PR TITLE
Fixed param typo

### DIFF
--- a/src/Manipulators/BaseManipulator.php
+++ b/src/Manipulators/BaseManipulator.php
@@ -20,7 +20,7 @@ abstract class BaseManipulator implements ManipulatorInterface
      */
     public function setParams(array $params): static
     {
-        $this->params = $params;
+        $this->params = array_filter($params, fn (string $key): bool => in_array($key, $this->getApiParams()), ARRAY_FILTER_USE_KEY);
 
         return $this;
     }
@@ -30,8 +30,6 @@ abstract class BaseManipulator implements ManipulatorInterface
      */
     public function getParam(string $name): mixed
     {
-        return array_key_exists($name, $this->params)
-            ? $this->params[$name]
-            : null;
+        return $this->params[$name] ?? null;
     }
 }

--- a/src/Manipulators/Border.php
+++ b/src/Manipulators/Border.php
@@ -13,7 +13,7 @@ class Border extends BaseManipulator
 {
     public function getApiParams(): array
     {
-        return ['border'];
+        return ['border', 'dpr'];
     }
 
     /**

--- a/src/Manipulators/Size.php
+++ b/src/Manipulators/Size.php
@@ -26,7 +26,7 @@ class Size extends BaseManipulator
 
     public function getApiParams(): array
     {
-        return ['w', 'f', 'fit', 'dpr'];
+        return ['w', 'h', 'fit', 'dpr'];
     }
 
     /**

--- a/src/Manipulators/Watermark.php
+++ b/src/Manipulators/Watermark.php
@@ -35,7 +35,7 @@ class Watermark extends BaseManipulator
 
     public function getApiParams(): array
     {
-        return ['mark', 'markw', 'markh', 'markx', 'marky', 'markpad', 'markfit', 'markpos', 'markalpha', 'dpr'];
+        return ['mark', 'markw', 'markh', 'markx', 'marky', 'markpad', 'markfit', 'markpos', 'markalpha', 'dpr', 'w', 'h'];
     }
 
     /**

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class ApiTest extends TestCase
 {
-    private $api;
+    private Api $api;
 
     public function setUp(): void
     {
@@ -24,30 +24,30 @@ class ApiTest extends TestCase
         \Mockery::close();
     }
 
-    public function testCreateInstance()
+    public function testCreateInstance(): void
     {
         $this->assertInstanceOf(Api::class, $this->api);
     }
 
-    public function testSetImageManager()
+    public function testSetImageManager(): void
     {
         $this->api->setImageManager(ImageManager::gd());
         $this->assertInstanceOf(ImageManager::class, $this->api->getImageManager());
     }
 
-    public function testGetImageManager()
+    public function testGetImageManager(): void
     {
         $this->assertInstanceOf(ImageManager::class, $this->api->getImageManager());
     }
 
-    public function testSetManipulators()
+    public function testSetManipulators(): void
     {
         $this->api->setManipulators([\Mockery::mock(ManipulatorInterface::class)]);
         $manipulators = $this->api->getManipulators();
         $this->assertInstanceOf(ManipulatorInterface::class, $manipulators[0]);
     }
 
-    public function testSetInvalidManipulator()
+    public function testSetInvalidManipulator(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Not a valid manipulator.');
@@ -55,7 +55,7 @@ class ApiTest extends TestCase
         $this->api->setManipulators([new \stdClass()]);
     }
 
-    public function testGetManipulators()
+    public function testGetManipulators(): void
     {
         $this->assertEquals([], $this->api->getManipulators());
     }
@@ -73,7 +73,7 @@ class ApiTest extends TestCase
         $this->assertEquals(array_merge(Api::GLOBAL_API_PARAMS, ['foo', 'bar', 'baz']), $api->getApiParams());
     }
 
-    public function testRun()
+    public function testRun(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('origin')->andReturn(\Mockery::mock('\Intervention\Image\Origin', function ($mock) {
@@ -96,7 +96,7 @@ class ApiTest extends TestCase
         $api = new Api($manager, [$manipulator]);
 
         $this->assertEquals('encoded', $api->run(
-            file_get_contents(dirname(__FILE__, 2).'/files/red-pixel.png'),
+            (string) file_get_contents(dirname(__FILE__, 2).'/files/red-pixel.png'),
             []
         ));
     }


### PR DESCRIPTION
Had a typo for an API param 

I wonder if we should throw an exception when a manipulator gets a param that's not allowed?