### PR TITLE
Use `cover` method from Intervention

### DIFF
--- a/docs/3.0/api/crop.md
+++ b/docs/3.0/api/crop.md
@@ -5,36 +5,36 @@ title: Crop
 
 # Crop
 
-## Fit `fit=crop`
+## Fit `fit=cover` - Crop to cover the dimensions
 
 Resizes the image to fill the width and height boundaries and crops any excess image data. The resulting image will match the width and height constraints without distorting the image.
 
 ~~~ html
-<img src="kayaks.jpg?w=300&h=300&fit=crop">
+<img src="kayaks.jpg?w=300&h=300&fit=cover">
 ~~~
 
 [![© Photo Joel Reynolds](https://glide.herokuapp.com/1.0/kayaks.jpg?w=300&h=300&fit=crop)](https://glide.herokuapp.com/1.0/kayaks.jpg?w=300&h=300&fit=crop)
 
 ### Crop Position
 
-You can also set where the image is cropped by adding a crop position. Accepts `crop-top-left`, `crop-top`, `crop-top-right`, `crop-left`, `crop-center`, `crop-right`, `crop-bottom-left`, `crop-bottom` or `crop-bottom-right`. Default is `crop-center`, and is the same as `crop`.
+You can also set where the image is cropped by adding a crop position. Accepts `cover-top-left`, `cover-top`, `cover-top-right`, `cover-left`, `cover-center`, `cover-right`, `cover-bottom-left`, `cover-bottom` or `cover-bottom-right`. Default is `cover-center`, and is the same as `crop`.
 
 ~~~ html
-<img src="kayaks.jpg?w=300&h=300&fit=crop-left">
+<img src="kayaks.jpg?w=300&h=300&fit=cover-left">
 ~~~
 
-### Crop Focal Point
+## Fit `fit=crop-x%-y%` - Crop based on Focal Point
 
 In addition to the crop position, you can be more specific about the exact crop position using a focal point. This is defined using two offset percentages: `crop-x%-y%`.
 
 ~~~ html
-<img src="kayaks.jpg?w=300&h=300&fit=crop-25-75">
+<img src="kayaks.jpg?w=300&h=300&fit=cover-25-75">
 ~~~
 
 You may also choose to zoom into your focal point by providing a third value: a float between 1 and 100. Each full step is the equivalent of a 100% zoom. (eg. `x%-y%-2` is the equivalent of viewing the image at 200%). The suggested range is 1-10.
 
 ~~~ html
-<img src="kayaks.jpg?w=300&h=300&fit=crop-25-75-2">
+<img src="kayaks.jpg?w=300&h=300&fit=cover-25-75-2">
 ~~~
 
 ## Crop `crop`

--- a/docs/3.0/api/crop.md
+++ b/docs/3.0/api/crop.md
@@ -28,13 +28,13 @@ You can also set where the image is cropped by adding a crop position. Accepts `
 In addition to the crop position, you can be more specific about the exact crop position using a focal point. This is defined using two offset percentages: `crop-x%-y%`.
 
 ~~~ html
-<img src="kayaks.jpg?w=300&h=300&fit=cover-25-75">
+<img src="kayaks.jpg?w=300&h=300&fit=crop-25-75">
 ~~~
 
 You may also choose to zoom into your focal point by providing a third value: a float between 1 and 100. Each full step is the equivalent of a 100% zoom. (eg. `x%-y%-2` is the equivalent of viewing the image at 200%). The suggested range is 1-10.
 
 ~~~ html
-<img src="kayaks.jpg?w=300&h=300&fit=cover-25-75-2">
+<img src="kayaks.jpg?w=300&h=300&fit=crop-25-75-2">
 ~~~
 
 ## Crop `crop`

--- a/docs/3.0/api/size.md
+++ b/docs/3.0/api/size.md
@@ -37,6 +37,7 @@ Sets how the image is fitted to its target dimensions.
 - `fill-max`: Resizes the image to fit within the width and height boundaries without cropping but upscaling the image if it's smaller. The finished image will have remaining space on either width or height (except if the aspect ratio of the new image is the same as the old image). The remaining space will be filled with the background color. The resulting image will match the constraining dimensions.
 - `stretch`: Stretches the image to fit the constraining dimensions exactly. The resulting image will fill the dimensions, and will not maintain the aspect ratio of the input image.
 - `cover`: Resizes the image to fill the width and height boundaries and crops any excess image data. The resulting image will match the width and height constraints without distorting the image. See the [crop](api/crop/) page for more information.
+- `crop`: Resizes the image to fill the width and height boundaries and crops any excess image data. (alias for `cover`).
 - `crop-x%-y%`: Resizes the image to fill the width and height boundaries and crops based on a focal point defined by `x%` (left offset) and `y%` (top offset). The resulting image will match the width and height constraints without distorting the image. See the [crop](api/crop/) page for more information.
 
 ~~~ html

--- a/docs/3.0/api/size.md
+++ b/docs/3.0/api/size.md
@@ -29,14 +29,15 @@ Sets the height of the image, in pixels.
 
 Sets how the image is fitted to its target dimensions.
 
-### Accepts: 
+### Accepts:
 
 - `contain`: Default. Resizes the image to fit within the width and height boundaries without cropping, distorting or altering the aspect ratio.
-- `max`: Resizes the image to fit within the width and height boundaries without cropping, distorting or altering the aspect ratio, and will also not increase the size of the image if it is smaller than the output size. 
+- `max`: Resizes the image to fit within the width and height boundaries without cropping, distorting or altering the aspect ratio, and will also not increase the size of the image if it is smaller than the output size.
 - `fill`: Resizes the image to fit within the width and height boundaries without cropping or distorting the image, and the remaining space is filled with the background color. The resulting image will match the constraining dimensions.
 - `fill-max`: Resizes the image to fit within the width and height boundaries without cropping but upscaling the image if it's smaller. The finished image will have remaining space on either width or height (except if the aspect ratio of the new image is the same as the old image). The remaining space will be filled with the background color. The resulting image will match the constraining dimensions.
 - `stretch`: Stretches the image to fit the constraining dimensions exactly. The resulting image will fill the dimensions, and will not maintain the aspect ratio of the input image.
-- `crop`: Resizes the image to fill the width and height boundaries and crops any excess image data. The resulting image will match the width and height constraints without distorting the image. See the [crop](api/crop/) page for more information.
+- `cover`: Resizes the image to fill the width and height boundaries and crops any excess image data. The resulting image will match the width and height constraints without distorting the image. See the [crop](api/crop/) page for more information.
+- `crop-x%-y%`: Resizes the image to fill the width and height boundaries and crops based on a focal point defined by `x%` (left offset) and `y%` (top offset). The resulting image will match the width and height constraints without distorting the image. See the [crop](api/crop/) page for more information.
 
 ~~~ html
 <img src="kayaks.jpg?w=300&h=300&fit=stretch">

--- a/docs/3.0/api/watermarks.md
+++ b/docs/3.0/api/watermarks.md
@@ -54,10 +54,11 @@ Sets how the watermark is fitted to its target dimensions.
 - `max`: Resizes the image to fit within the width and height boundaries without cropping, distorting or altering the aspect ratio, and will also not increase the size of the image if it is smaller than the output size.
 - `fill`: Resizes the image to fit within the width and height boundaries without cropping or distorting the image, and the remaining space is filled with the background color. The resulting image will match the constraining dimensions.
 - `stretch`: Stretches the image to fit the constraining dimensions exactly. The resulting image will fill the dimensions, and will not maintain the aspect ratio of the input image.
-- `crop`: Resizes the image to fill the width and height boundaries and crops any excess image data. The resulting image will match the width and height constraints without distorting the image. See the [crop](api/crop/) page for more information.
+- `cover`: Resizes the image to fill the width and height boundaries and crops any excess image data. The resulting image will match the width and height constraints without distorting the image. See the [crop](api/crop/) page for more information.
+- `crop-x%-y%`: Resizes the image to fill the width and height boundaries and crops based on a focal point defined by `x%` (left offset) and `y%` (top offset). The resulting image will match the width and height constraints without distorting the image. See the [crop](api/crop/) page for more information.
 
 ~~~ html
-<img src="kayaks.jpg?mark=logo.png&markw=200&markh=200&markfit=crop">
+<img src="kayaks.jpg?mark=logo.png&markw=200&markh=200&markfit=cover">
 ~~~
 
 ## X-offset `markx`

--- a/docs/3.0/config/defaults-and-presets.md
+++ b/docs/3.0/config/defaults-and-presets.md
@@ -42,12 +42,12 @@ $server = League\Glide\ServerFactory::create([
         'small' => [
             'w' => 200,
             'h' => 200,
-            'fit' => 'crop',
+            'fit' => 'cover',
         ],
         'medium' => [
             'w' => 600,
             'h' => 400,
-            'fit' => 'crop',
+            'fit' => 'cover',
         ]
     ]
 ]);
@@ -57,12 +57,12 @@ $server->setPresets([
     'small' => [
         'w' => 200,
         'h' => 200,
-        'fit' => 'crop',
+        'fit' => 'cover',
     ],
     'medium' => [
         'w' => 600,
         'h' => 400,
-        'fit' => 'crop',
+        'fit' => 'cover',
     ]
 ]);
 ~~~

--- a/docs/3.0/simple-example.md
+++ b/docs/3.0/simple-example.md
@@ -16,7 +16,7 @@ In your templates simply define how the image will be manipulated. Using Glide's
 <h1><?=$user->name?></h1>
 
 <!-- display profile image cropped to 300x400 -->
-<img src="/img/users/<?=$user->id?>.jpg?w=300&h=400&fit=crop">
+<img src="/img/users/<?=$user->id?>.jpg?w=300&h=400&fit=cover">
 ~~~
 
 <p class="message-notice">For simplicity this example has omitted HTTP signatures, however in a production environment it's very important to <a href="/2.0/config/security/">secure your images</a>.</p>

--- a/src/Manipulators/Size.php
+++ b/src/Manipulators/Size.php
@@ -366,7 +366,9 @@ class Size extends BaseManipulator
     {
         $position ??= str_replace('crop-', '', (string) $this->getParam('fit'));
 
-        return $image->cover($width, $height, $position ?? 'center');
+        $position = empty($position) || in_array($position, ['crop', 'cover']) ? 'center' : $position;
+
+        return $image->cover($width, $height, $position);
     }
 
     /**

--- a/src/Manipulators/Size.php
+++ b/src/Manipulators/Size.php
@@ -107,7 +107,7 @@ class Size extends BaseManipulator
     {
         $fit = (string) $this->getParam('fit');
 
-        if (in_array($fit, ['contain', 'fill', 'max', 'stretch', 'fill-max'], true)) {
+        if (in_array($fit, ['contain', 'fill', 'max', 'stretch', 'fill-max', 'cover'], true)) {
             return $fit;
         }
 

--- a/src/Manipulators/Size.php
+++ b/src/Manipulators/Size.php
@@ -111,7 +111,7 @@ class Size extends BaseManipulator
             return $fit;
         }
 
-        if (preg_match('/^(crop)(-top-left|-top|-top-right|-left|-center|-right|-bottom-left|-bottom|-bottom-right?)*$/', $fit)) {
+        if (preg_match('/^(crop|cover)(-top-left|-top|-top-right|-left|-center|-right|-bottom-left|-bottom|-bottom-right?)*$/', $fit)) {
             return 'cover';
         }
 
@@ -364,7 +364,7 @@ class Size extends BaseManipulator
      */
     public function runCoverResize(ImageInterface $image, int $width, int $height, ?string $position = null): ImageInterface
     {
-        $position ??= str_replace('crop-', '', (string) $this->getParam('fit'));
+        $position ??= str_replace(['crop-', 'cover-'], '', (string) $this->getParam('fit'));
 
         $position = empty($position) || in_array($position, ['crop', 'cover']) ? 'center' : $position;
 

--- a/src/Manipulators/Size.php
+++ b/src/Manipulators/Size.php
@@ -333,71 +333,7 @@ class Size extends BaseManipulator
      */
     public function runCropResize(ImageInterface $image, int $width, int $height): ImageInterface
     {
-        [$resize_width, $resize_height] = $this->resolveCropResizeDimensions($image, $width, $height);
-
-        $zoom = $this->getCrop()[2];
-
-        $image->scale((int) round($resize_width * $zoom), (int) round($resize_height * $zoom));
-
-        [$offset_x, $offset_y] = $this->resolveCropOffset($image, $width, $height);
-
-        return $image->crop($width, $height, $offset_x, $offset_y);
-    }
-
-    /**
-     * Resolve the crop resize dimensions.
-     *
-     * @param ImageInterface $image  The source image.
-     * @param int            $width  The width.
-     * @param int            $height The height.
-     *
-     * @return array The resize dimensions.
-     */
-    public function resolveCropResizeDimensions(ImageInterface $image, int $width, int $height): array
-    {
-        if ($height > $width * ($image->height() / $image->width())) {
-            return [$height * ($image->width() / $image->height()), $height];
-        }
-
-        return [$width, $width * ($image->height() / $image->width())];
-    }
-
-    /**
-     * Resolve the crop offset.
-     *
-     * @param ImageInterface $image  The source image.
-     * @param int            $width  The width.
-     * @param int            $height The height.
-     *
-     * @return array The crop offset.
-     */
-    public function resolveCropOffset(ImageInterface $image, int $width, int $height): array
-    {
-        [$offset_percentage_x, $offset_percentage_y] = $this->getCrop();
-
-        $offset_x = (int) (($image->width() * $offset_percentage_x / 100) - ($width / 2));
-        $offset_y = (int) (($image->height() * $offset_percentage_y / 100) - ($height / 2));
-
-        $max_offset_x = $image->width() - $width;
-        $max_offset_y = $image->height() - $height;
-
-        if ($offset_x < 0) {
-            $offset_x = 0;
-        }
-
-        if ($offset_y < 0) {
-            $offset_y = 0;
-        }
-
-        if ($offset_x > $max_offset_x) {
-            $offset_x = $max_offset_x;
-        }
-
-        if ($offset_y > $max_offset_y) {
-            $offset_y = $max_offset_y;
-        }
-
-        return [$offset_x, $offset_y];
+        return $image->cover($width, $height);
     }
 
     /**

--- a/tests/Manipulators/SizeTest.php
+++ b/tests/Manipulators/SizeTest.php
@@ -78,9 +78,10 @@ class SizeTest extends TestCase
         $this->assertSame('stretch', $this->manipulator->setParams(['fit' => 'stretch'])->getFit());
         $this->assertSame('cover', $this->manipulator->setParams(['fit' => 'cover'])->getFit());
         $this->assertSame('cover', $this->manipulator->setParams(['fit' => 'crop'])->getFit());
+        $this->assertSame('cover', $this->manipulator->setParams(['fit' => 'crop-bottom'])->getFit());
         $this->assertSame('cover', $this->manipulator->setParams(['fit' => 'crop-top-left'])->getFit());
         $this->assertSame('cover', $this->manipulator->setParams(['fit' => 'crop-center'])->getFit());
-        $this->assertSame('crop', $this->manipulator->setParams(['fit' => 'crop-27-75'])->getFit());
+        $this->assertSame('crop', $this->manipulator->setParams(['fit' => 'crop-25-75'])->getFit());
         $this->assertSame('contain', $this->manipulator->setParams(['fit' => 'invalid'])->getFit());
     }
 
@@ -286,13 +287,23 @@ class SizeTest extends TestCase
             $mock->shouldReceive('width')->andReturn(100);
             $mock->shouldReceive('height')->andReturn(100);
             $mock->shouldReceive('cover')->with(50, 50, 'top-left')->andReturn($mock)->once();
+            $mock->shouldReceive('cover')->with(50, 50, 'bottom')->andReturn($mock)->once();
+            $mock->shouldReceive('cover')->with(50, 50, 'bottom-right')->andReturn($mock)->once();
         });
 
         $this->manipulator->setParams(['w' => 50, 'h' => 50, 'fit' => 'crop-top-left']);
 
         $this->assertInstanceOf(
             ImageInterface::class,
-            $this->manipulator->run($image)
+            $this->manipulator->setParams(['w' => 50, 'h' => 50, 'fit' => 'crop-top-left'])->run($image)
+        );
+        $this->assertInstanceOf(
+            ImageInterface::class,
+            $this->manipulator->setParams(['w' => 50, 'h' => 50, 'fit' => 'crop-bottom'])->run($image)
+        );
+        $this->assertInstanceOf(
+            ImageInterface::class,
+            $this->manipulator->setParams(['w' => 50, 'h' => 50, 'fit' => 'crop-bottom-right'])->run($image)
         );
     }
 

--- a/tests/Manipulators/SizeTest.php
+++ b/tests/Manipulators/SizeTest.php
@@ -264,6 +264,22 @@ class SizeTest extends TestCase
         );
     }
 
+    public function testRunCoverResize()
+    {
+        $image = \Mockery::mock(ImageInterface::class, function ($mock) {
+            $mock->shouldReceive('width')->andReturn(100);
+            $mock->shouldReceive('height')->andReturn(100);
+            $mock->shouldReceive('cover')->with(50, 50, 'center')->andReturn($mock)->once();
+        });
+
+        $this->manipulator->setParams(['w' => 50, 'h' => 50, 'fit' => 'crop']);
+
+        $this->assertInstanceOf(
+            ImageInterface::class,
+            $this->manipulator->run($image)
+        );
+    }
+
     public function testRunCoverResizePosition()
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {

--- a/tests/Manipulators/SizeTest.php
+++ b/tests/Manipulators/SizeTest.php
@@ -76,7 +76,10 @@ class SizeTest extends TestCase
         $this->assertSame('fill-max', $this->manipulator->setParams(['fit' => 'fill-max'])->getFit());
         $this->assertSame('max', $this->manipulator->setParams(['fit' => 'max'])->getFit());
         $this->assertSame('stretch', $this->manipulator->setParams(['fit' => 'stretch'])->getFit());
+        $this->assertSame('cover', $this->manipulator->setParams(['fit' => 'cover'])->getFit());
         $this->assertSame('cover', $this->manipulator->setParams(['fit' => 'crop'])->getFit());
+        $this->assertSame('cover', $this->manipulator->setParams(['fit' => 'crop-top-left'])->getFit());
+        $this->assertSame('cover', $this->manipulator->setParams(['fit' => 'crop-center'])->getFit());
         $this->assertSame('crop', $this->manipulator->setParams(['fit' => 'crop-27-75'])->getFit());
         $this->assertSame('contain', $this->manipulator->setParams(['fit' => 'invalid'])->getFit());
     }

--- a/tests/Manipulators/SizeTest.php
+++ b/tests/Manipulators/SizeTest.php
@@ -77,6 +77,8 @@ class SizeTest extends TestCase
         $this->assertSame('max', $this->manipulator->setParams(['fit' => 'max'])->getFit());
         $this->assertSame('stretch', $this->manipulator->setParams(['fit' => 'stretch'])->getFit());
         $this->assertSame('cover', $this->manipulator->setParams(['fit' => 'cover'])->getFit());
+        $this->assertSame('cover', $this->manipulator->setParams(['fit' => 'cover-top-left'])->getFit());
+        $this->assertSame('cover', $this->manipulator->setParams(['fit' => 'cover-center'])->getFit());
         $this->assertSame('cover', $this->manipulator->setParams(['fit' => 'crop'])->getFit());
         $this->assertSame('cover', $this->manipulator->setParams(['fit' => 'crop-bottom'])->getFit());
         $this->assertSame('cover', $this->manipulator->setParams(['fit' => 'crop-top-left'])->getFit());
@@ -270,14 +272,17 @@ class SizeTest extends TestCase
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('width')->andReturn(100);
             $mock->shouldReceive('height')->andReturn(100);
-            $mock->shouldReceive('cover')->with(50, 50, 'center')->andReturn($mock)->once();
+            $mock->shouldReceive('cover')->with(50, 50, 'center')->andReturn($mock)->twice();
         });
-
-        $this->manipulator->setParams(['w' => 50, 'h' => 50, 'fit' => 'crop']);
 
         $this->assertInstanceOf(
             ImageInterface::class,
-            $this->manipulator->run($image)
+            $this->manipulator->setParams(['w' => 50, 'h' => 50, 'fit' => 'cover'])->run($image)
+        );
+
+        $this->assertInstanceOf(
+            ImageInterface::class,
+            $this->manipulator->setParams(['w' => 50, 'h' => 50, 'fit' => 'crop'])->run($image)
         );
     }
 
@@ -286,16 +291,18 @@ class SizeTest extends TestCase
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('width')->andReturn(100);
             $mock->shouldReceive('height')->andReturn(100);
-            $mock->shouldReceive('cover')->with(50, 50, 'top-left')->andReturn($mock)->once();
+            $mock->shouldReceive('cover')->with(50, 50, 'top-left')->andReturn($mock)->twice();
             $mock->shouldReceive('cover')->with(50, 50, 'bottom')->andReturn($mock)->once();
             $mock->shouldReceive('cover')->with(50, 50, 'bottom-right')->andReturn($mock)->once();
         });
 
-        $this->manipulator->setParams(['w' => 50, 'h' => 50, 'fit' => 'crop-top-left']);
-
         $this->assertInstanceOf(
             ImageInterface::class,
             $this->manipulator->setParams(['w' => 50, 'h' => 50, 'fit' => 'crop-top-left'])->run($image)
+        );
+        $this->assertInstanceOf(
+            ImageInterface::class,
+            $this->manipulator->setParams(['w' => 50, 'h' => 50, 'fit' => 'cover-top-left'])->run($image)
         );
         $this->assertInstanceOf(
             ImageInterface::class,

--- a/tests/Manipulators/SizeTest.php
+++ b/tests/Manipulators/SizeTest.php
@@ -26,18 +26,18 @@ class SizeTest extends TestCase
         $this->assertInstanceOf(Size::class, $this->manipulator);
     }
 
-    public function testSetMaxImageSize()
+    public function testSetMaxImageSize(): void
     {
         $this->manipulator->setMaxImageSize(500 * 500);
         $this->assertSame(500 * 500, $this->manipulator->getMaxImageSize());
     }
 
-    public function testGetMaxImageSize()
+    public function testGetMaxImageSize(): void
     {
         $this->assertNull($this->manipulator->getMaxImageSize());
     }
 
-    public function testRun()
+    public function testRun(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('width')->andReturn('200')->twice();
@@ -51,7 +51,7 @@ class SizeTest extends TestCase
         );
     }
 
-    public function testGetWidth()
+    public function testGetWidth(): void
     {
         $this->assertSame(100, $this->manipulator->setParams(['w' => 100])->getWidth());
         $this->assertSame(100, $this->manipulator->setParams(['w' => 100.1])->getWidth());
@@ -60,7 +60,7 @@ class SizeTest extends TestCase
         $this->assertSame(null, $this->manipulator->setParams(['w' => '-100'])->getWidth());
     }
 
-    public function testGetHeight()
+    public function testGetHeight(): void
     {
         $this->assertSame(100, $this->manipulator->setParams(['h' => 100])->getHeight());
         $this->assertSame(100, $this->manipulator->setParams(['h' => 100.1])->getHeight());
@@ -69,7 +69,7 @@ class SizeTest extends TestCase
         $this->assertSame(null, $this->manipulator->setParams(['h' => '-100'])->getHeight());
     }
 
-    public function testGetFit()
+    public function testGetFit(): void
     {
         $this->assertSame('contain', $this->manipulator->setParams(['fit' => 'contain'])->getFit());
         $this->assertSame('fill', $this->manipulator->setParams(['fit' => 'fill'])->getFit());
@@ -85,7 +85,7 @@ class SizeTest extends TestCase
         $this->assertSame('contain', $this->manipulator->setParams(['fit' => 'invalid'])->getFit());
     }
 
-    public function testGetCrop()
+    public function testGetCrop(): void
     {
         $this->assertSame([0, 0, 1.0], $this->manipulator->setParams(['fit' => 'crop-top-left'])->getCrop());
         $this->assertSame([0, 100, 1.0], $this->manipulator->setParams(['fit' => 'crop-bottom-left'])->getCrop());
@@ -110,7 +110,7 @@ class SizeTest extends TestCase
         $this->assertSame([50, 50, 1.0], $this->manipulator->setParams(['fit' => 'invalid'])->getCrop());
     }
 
-    public function testGetDpr()
+    public function testGetDpr(): void
     {
         $this->assertSame(1.0, $this->manipulator->setParams(['dpr' => 'invalid'])->getDpr());
         $this->assertSame(1.0, $this->manipulator->setParams(['dpr' => '-1'])->getDpr());
@@ -118,7 +118,7 @@ class SizeTest extends TestCase
         $this->assertSame(2.0, $this->manipulator->setParams(['dpr' => '2'])->getDpr());
     }
 
-    public function testResolveMissingDimensions()
+    public function testResolveMissingDimensions(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('width')->andReturn(400);
@@ -130,7 +130,7 @@ class SizeTest extends TestCase
         $this->assertSame([200, 100], $this->manipulator->resolveMissingDimensions($image, null, 100));
     }
 
-    public function testResolveMissingDimensionsWithOddDimensions()
+    public function testResolveMissingDimensionsWithOddDimensions(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('width')->andReturn(1024);
@@ -140,7 +140,7 @@ class SizeTest extends TestCase
         $this->assertSame([411, 222], $this->manipulator->resolveMissingDimensions($image, 411, null));
     }
 
-    public function testLimitImageSize()
+    public function testLimitImageSize(): void
     {
         $this->assertSame([1000, 1000], $this->manipulator->limitImageSize(1000, 1000));
         $this->manipulator->setMaxImageSize(500 * 500);
@@ -148,7 +148,7 @@ class SizeTest extends TestCase
         $this->assertSame([500, 500], $this->manipulator->limitImageSize(1000, 1000));
     }
 
-    public function testRunResize()
+    public function testRunResize(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('width')->andReturn(100)->times(4);
@@ -202,7 +202,7 @@ class SizeTest extends TestCase
         );
     }
 
-    public function testRunContainResize()
+    public function testRunContainResize(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('scale')->with(100, 100)->andReturn($mock)->once();
@@ -214,7 +214,7 @@ class SizeTest extends TestCase
         );
     }
 
-    public function testRunFillResize()
+    public function testRunFillResize(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('pad')->with(100, 100)->andReturn($mock)->once();
@@ -226,7 +226,7 @@ class SizeTest extends TestCase
         );
     }
 
-    public function testRunMaxResize()
+    public function testRunMaxResize(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('scaleDown')->with(100, 100)->andReturn($mock)->once();
@@ -238,7 +238,7 @@ class SizeTest extends TestCase
         );
     }
 
-    public function testRunStretchResize()
+    public function testRunStretchResize(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('resize')->with(100, 100)->andReturn($mock)->once();
@@ -250,7 +250,7 @@ class SizeTest extends TestCase
         );
     }
 
-    public function testRunCropResize()
+    public function testRunCropResize(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('width')->andReturn(100)->times(4);
@@ -265,7 +265,7 @@ class SizeTest extends TestCase
         );
     }
 
-    public function testRunCoverResize()
+    public function testRunCoverResize(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('width')->andReturn(100);
@@ -281,7 +281,7 @@ class SizeTest extends TestCase
         );
     }
 
-    public function testRunCoverResizePosition()
+    public function testRunCoverResizePosition(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('width')->andReturn(100);
@@ -307,7 +307,7 @@ class SizeTest extends TestCase
         );
     }
 
-    public function testResizeDoesNotRunWhenNoParamsAreSet()
+    public function testResizeDoesNotRunWhenNoParamsAreSet(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('width')->andReturn(100)->twice();
@@ -321,7 +321,7 @@ class SizeTest extends TestCase
         );
     }
 
-    public function testResizeDoesNotRunWhenSettingFitCropToCenterWithNoZoom()
+    public function testResizeDoesNotRunWhenSettingFitCropToCenterWithNoZoom(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('width')->andReturn(100)->twice();
@@ -337,7 +337,7 @@ class SizeTest extends TestCase
         );
     }
 
-    public function testResizeDoesRunWhenDimensionsAreTheSameAndTheCropZoomIsNotDefaultOne()
+    public function testResizeDoesRunWhenDimensionsAreTheSameAndTheCropZoomIsNotDefaultOne(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('width')->andReturn(100);

--- a/tests/Manipulators/SizeTest.php
+++ b/tests/Manipulators/SizeTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class SizeTest extends TestCase
 {
-    private $manipulator;
+    private Size $manipulator;
 
     public function setUp(): void
     {
@@ -21,9 +21,9 @@ class SizeTest extends TestCase
         \Mockery::close();
     }
 
-    public function testCreateInstance()
+    public function testCreateInstance(): void
     {
-        $this->assertInstanceOf('League\Glide\Manipulators\Size', $this->manipulator);
+        $this->assertInstanceOf(Size::class, $this->manipulator);
     }
 
     public function testSetMaxImageSize()
@@ -76,7 +76,8 @@ class SizeTest extends TestCase
         $this->assertSame('fill-max', $this->manipulator->setParams(['fit' => 'fill-max'])->getFit());
         $this->assertSame('max', $this->manipulator->setParams(['fit' => 'max'])->getFit());
         $this->assertSame('stretch', $this->manipulator->setParams(['fit' => 'stretch'])->getFit());
-        $this->assertSame('crop', $this->manipulator->setParams(['fit' => 'crop'])->getFit());
+        $this->assertSame('cover', $this->manipulator->setParams(['fit' => 'crop'])->getFit());
+        $this->assertSame('crop', $this->manipulator->setParams(['fit' => 'crop-27-75'])->getFit());
         $this->assertSame('contain', $this->manipulator->setParams(['fit' => 'invalid'])->getFit());
     }
 
@@ -188,6 +189,11 @@ class SizeTest extends TestCase
 
         $this->assertInstanceOf(
             ImageInterface::class,
+            $this->manipulator->runResize($image, 'crop-top-right', 100, 100)
+        );
+
+        $this->assertInstanceOf(
+            ImageInterface::class,
             $this->manipulator->runResize($image, 'invalid', 100, 100)
         );
     }
@@ -251,7 +257,23 @@ class SizeTest extends TestCase
 
         $this->assertInstanceOf(
             ImageInterface::class,
-            $this->manipulator->runCropResize($image, 100, 100, 'center')
+            $this->manipulator->runCropResize($image, 100, 100)
+        );
+    }
+
+    public function testRunCoverResizePosition()
+    {
+        $image = \Mockery::mock(ImageInterface::class, function ($mock) {
+            $mock->shouldReceive('width')->andReturn(100);
+            $mock->shouldReceive('height')->andReturn(100);
+            $mock->shouldReceive('cover')->with(50, 50, 'top-left')->andReturn($mock)->once();
+        });
+
+        $this->manipulator->setParams(['w' => 50, 'h' => 50, 'fit' => 'crop-top-left']);
+
+        $this->assertInstanceOf(
+            ImageInterface::class,
+            $this->manipulator->run($image)
         );
     }
 


### PR DESCRIPTION
* resolves #420

Intervention v3 has a `cover` method that works as intended for the `fit=crop` parameter.
https://image.intervention.io/v3/modifying/resizing#cropping--resizing-combined