### PR TITLE
Fix/remove implicit nullable parameters

### DIFF
--- a/src/Manipulators/Watermark.php
+++ b/src/Manipulators/Watermark.php
@@ -41,7 +41,7 @@ class Watermark extends BaseManipulator
      *
      * @param FilesystemOperator $watermarks The watermarks file system.
      */
-    public function __construct(FilesystemOperator $watermarks = null, $watermarksPathPrefix = '')
+    public function __construct(?FilesystemOperator $watermarks = null, $watermarksPathPrefix = '')
     {
         $this->setWatermarks($watermarks);
         $this->setWatermarksPathPrefix($watermarksPathPrefix);
@@ -54,7 +54,7 @@ class Watermark extends BaseManipulator
      *
      * @return void
      */
-    public function setWatermarks(FilesystemOperator $watermarks = null)
+    public function setWatermarks(?FilesystemOperator $watermarks = null)
     {
         $this->watermarks = $watermarks;
     }

--- a/src/Server.php
+++ b/src/Server.php
@@ -553,7 +553,7 @@ class Server
      *
      * @return void
      */
-    public function setResponseFactory(ResponseFactoryInterface $responseFactory = null)
+    public function setResponseFactory(?ResponseFactoryInterface $responseFactory = null)
     {
         $this->responseFactory = $responseFactory;
     }

--- a/src/Urls/UrlBuilder.php
+++ b/src/Urls/UrlBuilder.php
@@ -34,7 +34,7 @@ class UrlBuilder
      * @param string                  $baseUrl   The base URL.
      * @param SignatureInterface|null $signature The HTTP signature used to sign URLs.
      */
-    public function __construct($baseUrl = '', SignatureInterface $signature = null)
+    public function __construct($baseUrl = '', ?SignatureInterface $signature = null)
     {
         $this->setBaseUrl($baseUrl);
         $this->setSignature($signature);
@@ -64,7 +64,7 @@ class UrlBuilder
      *
      * @return void
      */
-    public function setSignature(SignatureInterface $signature = null)
+    public function setSignature(?SignatureInterface $signature = null)
     {
         $this->signature = $signature;
     }


### PR DESCRIPTION
Remove implicit nullable parameters as PHP 8.4 applications are recommended to explicitly declare the type as nullable. 

See: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated