### PR TITLE
Simplify Background::class manipulator

### DIFF
--- a/src/Manipulators/Background.php
+++ b/src/Manipulators/Background.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace League\Glide\Manipulators;
 
 use Intervention\Image\Interfaces\ImageInterface;
-use Intervention\Image\Origin;
 use League\Glide\Manipulators\Helpers\Color;
 
 class Background extends BaseManipulator
@@ -32,11 +31,6 @@ class Background extends BaseManipulator
 
         $color = (new Color($bg))->formatted();
 
-        return $image->driver()->createImage($image->width(), $image->height())
-            ->fill($color)
-            ->place($image, 'top-left', 0, 0)
-            ->setOrigin(
-                new Origin($image->origin()->mediaType())
-            );
+        return $image->blendTransparency($color);
     }
 }

--- a/tests/Manipulators/BackgroundTest.php
+++ b/tests/Manipulators/BackgroundTest.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace League\Glide\Manipulators;
 
-use Intervention\Image\Interfaces\DriverInterface;
 use Intervention\Image\Interfaces\ImageInterface;
-use Intervention\Image\Origin;
 use PHPUnit\Framework\TestCase;
 
 class BackgroundTest extends TestCase
 {
     private $manipulator;
+
+    public function setUp(): void
+    {
+        $this->manipulator = new Background();
+    }
 
     public function tearDown(): void
     {
@@ -26,27 +29,12 @@ class BackgroundTest extends TestCase
     public function testRun()
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
-            $originMock = \Mockery::mock(Origin::class, ['mediaType' => 'image/jpeg']);
-
-            $mock->shouldReceive('width')->andReturn(100)->once();
-            $mock->shouldReceive('height')->andReturn(100)->once();
-            $mock->shouldReceive('origin')->andReturn($originMock)->once();
-
-            $mock->shouldReceive('driver')->andReturn(\Mockery::mock(DriverInterface::class, function ($mock) {
-                $mock->shouldReceive('createImage')->with(100, 100)->andReturn(\Mockery::mock(ImageInterface::class, function ($mock) {
-                    $mock->shouldReceive('fill')->with('rgba(0, 0, 0, 1)')->andReturn(\Mockery::mock(ImageInterface::class, function ($mock) {
-                        $mock->shouldReceive('setOrigin')->withArgs(function ($arg1) {
-                            return $arg1 instanceof Origin;
-                        })->andReturn($mock)->once();
-                        $mock->shouldReceive('place')->andReturn($mock)->once();
-                    }))->once();
-                }))->once();
-            }))->once();
+            $mock->shouldReceive('blendTransparency')->with('rgba(0, 0, 0, 1)')->once();
         });
 
-        $border = new Background();
-
-        $this->assertInstanceOf(ImageInterface::class, $border->run($image));
-        $this->assertInstanceOf(ImageInterface::class, $border->setParams(['bg' => 'black'])->run($image));
+        $this->assertInstanceOf(
+            ImageInterface::class,
+            $this->manipulator->setParams(['bg' => 'black'])->run($image)
+        );
     }
 }


### PR DESCRIPTION
For the calls of the [Background `bg`](https://glide.thephpleague.com/3.0/api/background/) manipulator Intervention Image has already an own method [`blendTransparency()`](https://image.intervention.io/v3/basics/colors#merge-transparent-areas-with-color) to set the background color of the image. 

This patch simplifies the `Background::class` manipulator in that way and replaces the manual individual steps with the mentioned method.