### PR TITLE
Fix background color not being applied.

### DIFF
--- a/src/Manipulators/Size.php
+++ b/src/Manipulators/Size.php
@@ -299,7 +299,7 @@ class Size extends BaseManipulator
      */
     public function runFillResize(ImageInterface $image, int $width, int $height): ImageInterface
     {
-        return $image->pad($width, $height);
+        return $image->pad($width, $height, 'transparent');
     }
 
     /**
@@ -313,7 +313,7 @@ class Size extends BaseManipulator
      */
     public function runFillMaxResize(ImageInterface $image, int $width, int $height): ImageInterface
     {
-        return $image->contain($width, $height);
+        return $image->contain($width, $height, 'transparent');
     }
 
     /**
@@ -349,7 +349,7 @@ class Size extends BaseManipulator
 
         [$offset_x, $offset_y] = $this->resolveCropOffset($image, $width, $height);
 
-        return $image->crop($width, $height, $offset_x, $offset_y);
+        return $image->crop($width, $height, $offset_x, $offset_y, 'transparent');
     }
 
     /**

--- a/tests/Manipulators/SizeTest.php
+++ b/tests/Manipulators/SizeTest.php
@@ -219,7 +219,7 @@ class SizeTest extends TestCase
     public function testRunFillResize(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
-            $mock->shouldReceive('pad')->with(100, 100)->andReturn($mock)->once();
+            $mock->shouldReceive('pad')->with(100, 100, 'transparent')->andReturn($mock)->once();
         });
 
         $this->assertInstanceOf(
@@ -258,7 +258,7 @@ class SizeTest extends TestCase
             $mock->shouldReceive('width')->andReturn(100)->times(4);
             $mock->shouldReceive('height')->andReturn(100)->times(4);
             $mock->shouldReceive('scale')->with(100, 100)->andReturn($mock)->once();
-            $mock->shouldReceive('crop')->with(100, 100, 0, 0)->andReturn($mock)->once();
+            $mock->shouldReceive('crop')->with(100, 100, 0, 0, 'transparent')->andReturn($mock)->once();
         });
 
         $this->assertInstanceOf(


### PR DESCRIPTION
For the `Size` manipulator operations use a transparent background so that the background color, if specified, is applied by the `Background` manipulator.