### PR TITLE
Fix constructor call of Intervention\Image\ImageManager in docs

### DIFF
--- a/docs/3.0/config/setup.md
+++ b/docs/3.0/config/setup.md
@@ -58,9 +58,9 @@ $watermarks = new League\Flysystem\Filesystem(
 );
 
 // Set image manager
-$imageManager = new Intervention\Image\ImageManager([
-    'driver' => 'gd',
-]);
+$imageManager = new Intervention\Image\ImageManager(
+    new Intervention\Image\Drivers\Gd\Driver()
+);
 
 // Set manipulators
 $manipulators = [


### PR DESCRIPTION
Glide 3 uses Intervention Image 3. This patch adapts the documentation to the 3.x API.