### PR TITLE
Revert "Simplify Background::class manipulator"

### DIFF
--- a/src/Manipulators/Background.php
+++ b/src/Manipulators/Background.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace League\Glide\Manipulators;
 
 use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\Origin;
 use League\Glide\Manipulators\Helpers\Color;
 
 class Background extends BaseManipulator
@@ -31,6 +32,11 @@ class Background extends BaseManipulator
 
         $color = (new Color($bg))->formatted();
 
-        return $image->blendTransparency($color);
+        return $image->driver()->createImage($image->width(), $image->height())
+            ->fill($color)
+            ->place($image, 'top-left', 0, 0)
+            ->setOrigin(
+                new Origin($image->origin()->mediaType())
+            );
     }
 }

--- a/tests/Manipulators/BackgroundTest.php
+++ b/tests/Manipulators/BackgroundTest.php
@@ -4,17 +4,14 @@ declare(strict_types=1);
 
 namespace League\Glide\Manipulators;
 
+use Intervention\Image\Interfaces\DriverInterface;
 use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\Origin;
 use PHPUnit\Framework\TestCase;
 
 class BackgroundTest extends TestCase
 {
     private $manipulator;
-
-    public function setUp(): void
-    {
-        $this->manipulator = new Background();
-    }
 
     public function tearDown(): void
     {
@@ -29,12 +26,27 @@ class BackgroundTest extends TestCase
     public function testRun()
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
-            $mock->shouldReceive('blendTransparency')->with('rgba(0, 0, 0, 1)')->once();
+            $originMock = \Mockery::mock(Origin::class, ['mediaType' => 'image/jpeg']);
+
+            $mock->shouldReceive('width')->andReturn(100)->once();
+            $mock->shouldReceive('height')->andReturn(100)->once();
+            $mock->shouldReceive('origin')->andReturn($originMock)->once();
+
+            $mock->shouldReceive('driver')->andReturn(\Mockery::mock(DriverInterface::class, function ($mock) {
+                $mock->shouldReceive('createImage')->with(100, 100)->andReturn(\Mockery::mock(ImageInterface::class, function ($mock) {
+                    $mock->shouldReceive('fill')->with('rgba(0, 0, 0, 1)')->andReturn(\Mockery::mock(ImageInterface::class, function ($mock) {
+                        $mock->shouldReceive('setOrigin')->withArgs(function ($arg1) {
+                            return $arg1 instanceof Origin;
+                        })->andReturn($mock)->once();
+                        $mock->shouldReceive('place')->andReturn($mock)->once();
+                    }))->once();
+                }))->once();
+            }))->once();
         });
 
-        $this->assertInstanceOf(
-            ImageInterface::class,
-            $this->manipulator->setParams(['bg' => 'black'])->run($image)
-        );
+        $border = new Background();
+
+        $this->assertInstanceOf(ImageInterface::class, $border->run($image));
+        $this->assertInstanceOf(ImageInterface::class, $border->setParams(['bg' => 'black'])->run($image));
     }
 }


### PR DESCRIPTION
Blending color is used only when outputting to image format which do not support tranparency but the background color when specified should be always used regardless of the output format.

This reverts commit bbf0976365820c50557a541282d6fc15e6325211.