### PR TITLE
Migrate to Intervention Image v4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1', '8.2', '8.3', '8.4', '8.5']
+        php-version: ['8.3', '8.4', '8.5']
         dependencies: [highest]
         include:
-          - php-version: '8.1'
+          - php-version: '8.3'
             dependencies: lowest
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-cli
+FROM php:8.3-cli
 
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "intervention/image": "^3.9.1",
+        "php": "^8.3",
+        "intervention/image": "^4.0",
         "league/flysystem": "^3.0",
         "psr/http-message": "^1.0|^2.0"
     },

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -46,8 +46,8 @@ class Api implements ApiInterface
      * Create API instance.
      *
      * @param ImageManagerInterface $imageManager Intervention image manager.
-     * @param array        $manipulators Collection of manipulators.
-     * @param Encoder|null $encoder      Image encoder.
+     * @param array                 $manipulators Collection of manipulators.
+     * @param Encoder|null          $encoder      Image encoder.
      */
     public function __construct(ImageManagerInterface $imageManager, array $manipulators, ?Encoder $encoder = null)
     {

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace League\Glide\Api;
 
-use Intervention\Image\ImageManager;
 use Intervention\Image\Interfaces\ImageInterface;
 use Intervention\Image\Interfaces\ImageManagerInterface;
 use League\Glide\Manipulators\ManipulatorInterface;

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace League\Glide\Api;
 
-use Intervention\Image\Decoders\BinaryImageDecoder;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\Interfaces\ImageManagerInterface;
 use League\Glide\Manipulators\ManipulatorInterface;
 
 class Api implements ApiInterface
@@ -21,7 +21,7 @@ class Api implements ApiInterface
     /**
      * Intervention image manager.
      */
-    protected ImageManager $imageManager;
+    protected ImageManagerInterface $imageManager;
 
     /**
      * Collection of manipulators.
@@ -45,11 +45,11 @@ class Api implements ApiInterface
     /**
      * Create API instance.
      *
-     * @param ImageManager $imageManager Intervention image manager.
+     * @param ImageManagerInterface $imageManager Intervention image manager.
      * @param array        $manipulators Collection of manipulators.
      * @param Encoder|null $encoder      Image encoder.
      */
-    public function __construct(ImageManager $imageManager, array $manipulators, ?Encoder $encoder = null)
+    public function __construct(ImageManagerInterface $imageManager, array $manipulators, ?Encoder $encoder = null)
     {
         $this->setImageManager($imageManager);
         $this->setManipulators($manipulators);
@@ -60,9 +60,9 @@ class Api implements ApiInterface
     /**
      * Set the image manager.
      *
-     * @param ImageManager $imageManager Intervention image manager.
+     * @param ImageManagerInterface $imageManager Intervention image manager.
      */
-    public function setImageManager(ImageManager $imageManager): void
+    public function setImageManager(ImageManagerInterface $imageManager): void
     {
         $this->imageManager = $imageManager;
     }
@@ -70,9 +70,9 @@ class Api implements ApiInterface
     /**
      * Get the image manager.
      *
-     * @return ImageManager Intervention image manager.
+     * @return ImageManagerInterface Intervention image manager.
      */
-    public function getImageManager(): ImageManager
+    public function getImageManager(): ImageManagerInterface
     {
         return $this->imageManager;
     }
@@ -133,7 +133,7 @@ class Api implements ApiInterface
      */
     public function run(string $source, array $params): string
     {
-        $image = $this->imageManager->read($source, BinaryImageDecoder::class);
+        $image = $this->imageManager->decodeBinary($source);
 
         foreach ($this->manipulators as $manipulator) {
             $manipulator->setParams($params);

--- a/src/Api/Encoder.php
+++ b/src/Api/Encoder.php
@@ -90,7 +90,7 @@ class Encoder
                 throw new \Exception("Invalid format provided: {$format}");
         }
 
-        return $image->encodeByExtension($format, ...$encoderOptions);
+        return $image->encodeUsingFileExtension($format, ...$encoderOptions);
     }
 
     /**

--- a/src/Manipulators/Background.php
+++ b/src/Manipulators/Background.php
@@ -34,7 +34,7 @@ class Background extends BaseManipulator
 
         return $image->driver()->createImage($image->width(), $image->height())
             ->fill($color)
-            ->place($image, 'top-left', 0, 0)
+            ->insert($image, 0, 0, 'top-left')
             ->setOrigin(
                 new Origin($image->origin()->mediaType())
             );

--- a/src/Manipulators/Border.php
+++ b/src/Manipulators/Border.php
@@ -30,7 +30,7 @@ class Border extends BaseManipulator
         if ($border) {
             [$width, $color, $method] = $border;
 
-            return $this->{'run'.$method}($image, $width, $color);
+            return $this->{'run' . $method}($image, $width, $color);
         }
 
         return $image;
@@ -116,7 +116,8 @@ class Border extends BaseManipulator
     {
         $dpr = $this->getParam('dpr');
 
-        if (!is_numeric($dpr)
+        if (
+            !is_numeric($dpr)
             || $dpr < 0
             || $dpr > 8
         ) {
@@ -137,17 +138,14 @@ class Border extends BaseManipulator
      */
     public function runOverlay(ImageInterface $image, float $width, string $color): ImageInterface
     {
-        return $image->drawRectangle(
-            (int) round($width / 2),
-            (int) round($width / 2),
-            function (RectangleFactory $rectangle) use ($image, $width, $color) {
-                $rectangle->size(
-                    (int) round($image->width() - $width),
-                    (int) round($image->height() - $width),
-                );
-                $rectangle->border($color, intval($width));
-            }
-        );
+        return $image->drawRectangle(function (RectangleFactory $rectangle) use ($image, $width, $color) {
+            $rectangle->at((int) round($width / 2), (int) round($width / 2));
+            $rectangle->size(
+                (int) round($image->width() - $width),
+                (int) round($image->height() - $width),
+            );
+            $rectangle->border($color, intval($width));
+        });
     }
 
     /**

--- a/src/Manipulators/Border.php
+++ b/src/Manipulators/Border.php
@@ -30,7 +30,7 @@ class Border extends BaseManipulator
         if ($border) {
             [$width, $color, $method] = $border;
 
-            return $this->{'run' . $method}($image, $width, $color);
+            return $this->{'run'.$method}($image, $width, $color);
         }
 
         return $image;

--- a/src/Manipulators/Filter.php
+++ b/src/Manipulators/Filter.php
@@ -38,7 +38,7 @@ class Filter extends BaseManipulator
      */
     public function runGreyscaleFilter(ImageInterface $image): ImageInterface
     {
-        return $image->greyscale();
+        return $image->grayscale();
     }
 
     /**
@@ -50,7 +50,7 @@ class Filter extends BaseManipulator
      */
     public function runSepiaFilter(ImageInterface $image): ImageInterface
     {
-        $image->greyscale()
+        $image->grayscale()
             ->brightness(-10)
             ->contrast(10)
             ->colorize(38, 27, 12)

--- a/src/Manipulators/Flip.php
+++ b/src/Manipulators/Flip.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace League\Glide\Manipulators;
 
+use Intervention\Image\Direction;
 use Intervention\Image\Interfaces\ImageInterface;
 
 class Flip extends BaseManipulator
@@ -26,9 +27,9 @@ class Flip extends BaseManipulator
 
         if (null !== $flip) {
             return match ($flip) {
-                'both' => $image->flip()->flop(),
-                'v' => $image->flip(),
-                'h' => $image->flop(),
+                'both' => $image->flip(Direction::HORIZONTAL)->flip(Direction::VERTICAL),
+                'v' => $image->flip(Direction::VERTICAL),
+                'h' => $image->flip(Direction::HORIZONTAL),
                 default => $image,
             };
         }

--- a/src/Manipulators/Orientation.php
+++ b/src/Manipulators/Orientation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace League\Glide\Manipulators;
 
+use Intervention\Image\Direction;
 use Intervention\Image\Interfaces\ImageInterface;
 
 class Orientation extends BaseManipulator
@@ -26,12 +27,12 @@ class Orientation extends BaseManipulator
 
         if ('auto' === $orientation) {
             return match ($image->exif('Orientation')) {
-                2 => $image->flip(),
+                2 => $image->flip(Direction::VERTICAL),
                 3 => $image->rotate(180),
-                4 => $image->rotate(180)->flip(),
-                5 => $image->rotate(270)->flip(),
+                4 => $image->rotate(180)->flip(Direction::VERTICAL),
+                5 => $image->rotate(270)->flip(Direction::VERTICAL),
                 6 => $image->rotate(270),
-                7 => $image->rotate(90)->flip(),
+                7 => $image->rotate(90)->flip(Direction::VERTICAL),
                 8 => $image->rotate(90),
                 default => $image,
             };

--- a/src/Manipulators/Size.php
+++ b/src/Manipulators/Size.php
@@ -300,7 +300,7 @@ class Size extends BaseManipulator
      */
     public function runFillResize(ImageInterface $image, int $width, int $height): ImageInterface
     {
-        return $image->containDown($width, $height, (string) Color::transparent());
+        return $image->containDown($width, $height, Color::transparent()->toString());
     }
 
     /**

--- a/src/Manipulators/Size.php
+++ b/src/Manipulators/Size.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace League\Glide\Manipulators;
 
-use Intervention\Image\Geometry\Rectangle;
+use Intervention\Image\Color;
 use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\Size as ImageSize;
 
 class Size extends BaseManipulator
 {
@@ -159,7 +160,7 @@ class Size extends BaseManipulator
         }
 
         if (is_null($width) || is_null($height)) {
-            $size = (new Rectangle($image->width(), $image->height()))
+            $size = (new ImageSize($image->width(), $image->height()))
                 ->scale($width, $height);
 
             $width = $size->width();
@@ -299,7 +300,7 @@ class Size extends BaseManipulator
      */
     public function runFillResize(ImageInterface $image, int $width, int $height): ImageInterface
     {
-        return $image->pad($width, $height, 'transparent');
+        return $image->containDown($width, $height, (string) Color::transparent());
     }
 
     /**
@@ -313,7 +314,7 @@ class Size extends BaseManipulator
      */
     public function runFillMaxResize(ImageInterface $image, int $width, int $height): ImageInterface
     {
-        return $image->contain($width, $height, 'transparent');
+        return $image->contain($width, $height, (string) Color::transparent());
     }
 
     /**
@@ -349,7 +350,7 @@ class Size extends BaseManipulator
 
         [$offset_x, $offset_y] = $this->resolveCropOffset($image, $width, $height);
 
-        return $image->crop($width, $height, $offset_x, $offset_y, 'transparent');
+        return $image->crop($width, $height, $offset_x, $offset_y, (string) Color::transparent());
     }
 
     /**

--- a/src/Manipulators/Size.php
+++ b/src/Manipulators/Size.php
@@ -314,7 +314,7 @@ class Size extends BaseManipulator
      */
     public function runFillMaxResize(ImageInterface $image, int $width, int $height): ImageInterface
     {
-        return $image->contain($width, $height, (string) Color::transparent());
+        return $image->contain($width, $height, Color::transparent()->toString());
     }
 
     /**
@@ -350,7 +350,7 @@ class Size extends BaseManipulator
 
         [$offset_x, $offset_y] = $this->resolveCropOffset($image, $width, $height);
 
-        return $image->crop($width, $height, $offset_x, $offset_y, (string) Color::transparent());
+        return $image->crop($width, $height, $offset_x, $offset_y, Color::transparent()->toString());
     }
 
     /**

--- a/src/Manipulators/Watermark.php
+++ b/src/Manipulators/Watermark.php
@@ -114,7 +114,7 @@ class Watermark extends BaseManipulator
         ]);
         $watermark = $size->run($watermark);
 
-        return $image->place($watermark, $markpos, intval($markx), intval($marky), $markalpha);
+        return $image->insert($watermark, intval($markx), intval($marky), $markpos, $markalpha);
     }
 
     /**
@@ -145,7 +145,7 @@ class Watermark extends BaseManipulator
             if ($this->watermarks->fileExists($path)) {
                 $source = $this->watermarks->read($path);
 
-                $mark = $image->driver()->handleInput($source);
+                $mark = $image->driver()->decodeImage($source);
             }
         } catch (FilesystemV2Exception $exception) {
             throw new FilesystemException('Could not read the image `'.$path.'`.');

--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace League\Glide;
 
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
 use Intervention\Image\ImageManager;
+use Intervention\Image\Interfaces\ImageManagerInterface;
 use League\Flysystem\Filesystem;
 use League\Flysystem\FilesystemOperator;
 use League\Flysystem\Local\LocalFilesystemAdapter;
@@ -229,9 +232,9 @@ class ServerFactory
     /**
      * Get Intervention image manager.
      *
-     * @return ImageManager Intervention image manager.
+     * @return ImageManagerInterface Intervention image manager.
      */
-    public function getImageManager(): ImageManager
+    public function getImageManager(): ImageManagerInterface
     {
         $driver = 'gd';
 
@@ -239,11 +242,11 @@ class ServerFactory
             $driver = $this->config['driver'];
         }
 
-        return match ($driver) {
-            'gd' => ImageManager::gd(),
-            'imagick' => ImageManager::imagick(),
-            default => ImageManager::withDriver($driver),
-        };
+        return ImageManager::usingDriver(match ($driver) {
+            'gd' => GdDriver::class,
+            'imagick' => ImagickDriver::class,
+            default => $driver,
+        });
     }
 
     /**

--- a/tests/Api/ApiTest.php
+++ b/tests/Api/ApiTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace League\Glide\Api;
 
+use Intervention\Image\Drivers\Gd\Driver;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Interfaces\EncodedImageInterface;
 use Intervention\Image\Interfaces\ImageInterface;
@@ -16,7 +17,7 @@ class ApiTest extends TestCase
 
     public function setUp(): void
     {
-        $this->api = new Api(ImageManager::gd(), []);
+        $this->api = new Api(ImageManager::usingDriver(Driver::class), []);
     }
 
     public function tearDown(): void
@@ -31,7 +32,7 @@ class ApiTest extends TestCase
 
     public function testSetImageManager(): void
     {
-        $this->api->setImageManager(ImageManager::gd());
+        $this->api->setImageManager(ImageManager::usingDriver(Driver::class));
         $this->assertInstanceOf(ImageManager::class, $this->api->getImageManager());
     }
 
@@ -69,7 +70,7 @@ class ApiTest extends TestCase
             $mock->shouldReceive('getApiParams')->andReturn(['foo', 'baz']);
         });
 
-        $api = new Api(ImageManager::gd(), [$manipulator1, $manipulator2]);
+        $api = new Api(ImageManager::usingDriver(Driver::class), [$manipulator1, $manipulator2]);
         $this->assertEquals(array_merge(Api::GLOBAL_API_PARAMS, ['foo', 'bar', 'baz']), $api->getApiParams());
     }
 
@@ -80,12 +81,12 @@ class ApiTest extends TestCase
                 $mock->shouldReceive('mediaType')->andReturn('image/png');
             }));
 
-            $mock->shouldReceive('encodeByExtension')->with('png')->andReturn(\Mockery::mock(EncodedImageInterface::class, function ($mock) {
+            $mock->shouldReceive('encodeUsingFileExtension')->with('png')->andReturn(\Mockery::mock(EncodedImageInterface::class, function ($mock) {
                 $mock->shouldReceive('toString')->andReturn('encoded');
             }));
         });
 
-        $manager = ImageManager::gd();
+        $manager = ImageManager::usingDriver(Driver::class);
 
         $manipulator = \Mockery::mock(ManipulatorInterface::class, function ($mock) use ($image) {
             $mock->shouldReceive('setParams')->with([]);

--- a/tests/Api/EncoderTest.php
+++ b/tests/Api/EncoderTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace League\Glide\Api;
 
-use Intervention\Image\Encoders\MediaTypeEncoder;
+use Intervention\Image\Drivers\Gd\Driver as GdDriver;
+use Intervention\Image\Drivers\Imagick\Driver as ImagickDriver;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Interfaces\EncodedImageInterface;
 use Intervention\Image\Interfaces\ImageInterface;
+use Intervention\Image\MediaType;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
@@ -24,26 +26,27 @@ class EncoderTest extends TestCase
 
     public function setUp(): void
     {
-        $manager = ImageManager::gd();
-        $this->jpg = $manager->read(
-            $manager->create(100, 100)->encode(new MediaTypeEncoder('image/jpeg'))->toFilePointer()
+        $manager = ImageManager::usingDriver(GdDriver::class);
+
+        $this->jpg = $manager->decode(
+            $manager->createImage(100, 100)->encodeUsingMediaType(MediaType::IMAGE_JPEG)->toStream()
         );
-        $this->png = $manager->read(
-            $manager->create(100, 100)->encode(new MediaTypeEncoder('image/png'))->toFilePointer()
+        $this->png = $manager->decode(
+            $manager->createImage(100, 100)->encodeUsingMediaType(MediaType::IMAGE_PNG)->toStream()
         );
-        $this->gif = $manager->read(
-            $manager->create(100, 100)->encode(new MediaTypeEncoder('image/gif'))->toFilePointer()
+        $this->gif = $manager->decode(
+            $manager->createImage(100, 100)->encodeUsingMediaType(MediaType::IMAGE_GIF)->toStream()
         );
 
         if (function_exists('imagecreatefromwebp')) {
-            $this->webp = $manager->read(
-                $manager->create(100, 100)->encode(new MediaTypeEncoder('image/webp'))->toFilePointer()
+            $this->webp = $manager->decode(
+                $manager->createImage(100, 100)->encodeUsingMediaType(MediaType::IMAGE_WEBP)->toStream()
             );
         }
 
         if (function_exists('imagecreatefromavif')) {
-            $this->avif = $manager->read(
-                $manager->create(100, 100)->encode(new MediaTypeEncoder('image/avif'))->toFilePointer()
+            $this->avif = $manager->decode(
+                $manager->createImage(100, 100)->encodeUsingMediaType(MediaType::IMAGE_AVIF)->toStream()
             );
         }
 
@@ -164,13 +167,13 @@ class EncoderTest extends TestCase
                 'The imagick extension is not available.'
             );
         }
-        $manager = ImageManager::imagick();
+        $manager = ImageManager::usingDriver(ImagickDriver::class);
         // These need to be recreated with the imagick driver selected in the manager
-        $this->jpg = $manager->read($manager->create(100, 100)->encode(new MediaTypeEncoder('image/jpeg'))->toFilePointer());
-        $this->png = $manager->read($manager->create(100, 100)->encode(new MediaTypeEncoder('image/png'))->toFilePointer());
-        $this->gif = $manager->read($manager->create(100, 100)->encode(new MediaTypeEncoder('image/gif'))->toFilePointer());
-        $this->heic = $manager->read($manager->create(100, 100)->encode(new MediaTypeEncoder('image/heic'))->toFilePointer());
-        $this->tif = $manager->read($manager->create(100, 100)->encode(new MediaTypeEncoder('image/tiff'))->toFilePointer());
+        $this->jpg = $manager->decode($manager->createImage(100, 100)->encodeUsingMediaType(MediaType::IMAGE_JPEG)->toStream());
+        $this->png = $manager->decode($manager->createImage(100, 100)->encodeUsingMediaType(MediaType::IMAGE_PNG)->toStream());
+        $this->gif = $manager->decode($manager->createImage(100, 100)->encodeUsingMediaType(MediaType::IMAGE_GIF)->toStream());
+        $this->heic = $manager->decode($manager->createImage(100, 100)->encodeUsingMediaType(MediaType::IMAGE_HEIC)->toStream());
+        $this->tif = $manager->decode($manager->createImage(100, 100)->encodeUsingMediaType(MediaType::IMAGE_TIFF)->toStream());
 
         $this->assertSame('image/tiff', $this->getMime($this->encoder->setParams(['fm' => 'tiff'])->run($this->jpg)));
         $this->assertSame('image/tiff', $this->getMime($this->encoder->setParams(['fm' => 'tiff'])->run($this->png)));

--- a/tests/Manipulators/BackgroundTest.php
+++ b/tests/Manipulators/BackgroundTest.php
@@ -38,7 +38,7 @@ class BackgroundTest extends TestCase
                         $mock->shouldReceive('setOrigin')->withArgs(function ($arg1) {
                             return $arg1 instanceof Origin;
                         })->andReturn($mock)->once();
-                        $mock->shouldReceive('place')->andReturn($mock)->once();
+                        $mock->shouldReceive('insert')->andReturn($mock)->once();
                     }))->once();
                 }))->once();
             }))->once();

--- a/tests/Manipulators/BorderTest.php
+++ b/tests/Manipulators/BorderTest.php
@@ -97,8 +97,9 @@ class BorderTest extends TestCase
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
             $mock->shouldReceive('width')->andReturn(100)->once();
             $mock->shouldReceive('height')->andReturn(100)->once();
-            $mock->shouldReceive('drawRectangle')->with(5, 5, \Mockery::on(function ($closure) {
+            $mock->shouldReceive('drawRectangle')->with(\Mockery::on(function ($closure) {
                 $mock2 = \Mockery::mock(RectangleFactory::class, function ($mock2) {
+                    $mock2->shouldReceive('at')->with(5, 5)->once();
                     $mock2->shouldReceive('size')->once();
                     $mock2->shouldReceive('border')->once();
                 });

--- a/tests/Manipulators/FilterTest.php
+++ b/tests/Manipulators/FilterTest.php
@@ -29,7 +29,7 @@ class FilterTest extends TestCase
     public function testRun()
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
-            $mock->shouldReceive('greyscale')->twice()->andReturn($mock)
+            $mock->shouldReceive('grayscale')->twice()->andReturn($mock)
                  ->shouldReceive('brightness')->with(-10)->twice()->andReturn($mock)
                  ->shouldReceive('contrast')->with(10)->twice()->andReturn($mock)
                  ->shouldReceive('colorize')->with(38, 27, 12)->once()->andReturn($mock);
@@ -54,7 +54,7 @@ class FilterTest extends TestCase
     public function testRunGreyscaleFilter()
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
-            $mock->shouldReceive('greyscale')->andReturn($mock)->once();
+            $mock->shouldReceive('grayscale')->andReturn($mock)->once();
         });
 
         $this->assertInstanceOf(
@@ -66,7 +66,7 @@ class FilterTest extends TestCase
     public function testRunSepiaFilter()
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
-            $mock->shouldReceive('greyscale')->once()->andReturn($mock)
+            $mock->shouldReceive('grayscale')->once()->andReturn($mock)
                  ->shouldReceive('brightness')->with(-10)->twice()->andReturn($mock)
                  ->shouldReceive('contrast')->with(10)->twice()->andReturn($mock)
                  ->shouldReceive('colorize')->with(38, 27, 12)->once()->andReturn($mock);

--- a/tests/Manipulators/FlipTest.php
+++ b/tests/Manipulators/FlipTest.php
@@ -29,8 +29,7 @@ class FlipTest extends TestCase
     public function testRun()
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
-            $mock->shouldReceive('flip')->andReturn($mock)->once();
-            $mock->shouldReceive('flop')->andReturn($mock)->once();
+            $mock->shouldReceive('flip')->andReturn($mock)->twice();
         });
 
         $this->assertInstanceOf(
@@ -47,8 +46,7 @@ class FlipTest extends TestCase
     public function testRunBoth()
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
-            $mock->shouldReceive('flip')->andReturn($mock)->once();
-            $mock->shouldReceive('flop')->andReturn($mock)->once();
+            $mock->shouldReceive('flip')->andReturn($mock)->twice();
         });
 
         $this->assertInstanceOf(

--- a/tests/Manipulators/SizeTest.php
+++ b/tests/Manipulators/SizeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace League\Glide\Manipulators;
 
+use Intervention\Image\Color;
 use Intervention\Image\Interfaces\ImageInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -158,7 +159,7 @@ class SizeTest extends TestCase
             $mock->shouldReceive('crop')->andReturn($mock)->once();
             $mock->shouldReceive('contain')->andReturn($mock)->once();
             $mock->shouldReceive('resize')->with(100, 100)->andReturn($mock)->once();
-            $mock->shouldReceive('pad')->andReturn($mock)->once();
+            $mock->shouldReceive('containDown')->andReturn($mock)->once();
             $mock->shouldReceive('scaleDown')->with(100, 100)->andReturn($mock)->times(1);
             $mock->shouldReceive('scale')->with(100, 100)->andReturn($mock)->times(2);
         });
@@ -219,7 +220,7 @@ class SizeTest extends TestCase
     public function testRunFillResize(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
-            $mock->shouldReceive('pad')->with(100, 100, 'transparent')->andReturn($mock)->once();
+            $mock->shouldReceive('containDown')->with(100, 100, (string) Color::transparent())->andReturn($mock)->once();
         });
 
         $this->assertInstanceOf(
@@ -258,7 +259,7 @@ class SizeTest extends TestCase
             $mock->shouldReceive('width')->andReturn(100)->times(4);
             $mock->shouldReceive('height')->andReturn(100)->times(4);
             $mock->shouldReceive('scale')->with(100, 100)->andReturn($mock)->once();
-            $mock->shouldReceive('crop')->with(100, 100, 0, 0, 'transparent')->andReturn($mock)->once();
+            $mock->shouldReceive('crop')->with(100, 100, 0, 0, (string) Color::transparent())->andReturn($mock)->once();
         });
 
         $this->assertInstanceOf(

--- a/tests/Manipulators/SizeTest.php
+++ b/tests/Manipulators/SizeTest.php
@@ -220,7 +220,7 @@ class SizeTest extends TestCase
     public function testRunFillResize(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
-            $mock->shouldReceive('containDown')->with(100, 100, (string) Color::transparent())->andReturn($mock)->once();
+            $mock->shouldReceive('containDown')->with(100, 100, Color::transparent()->toString())->andReturn($mock)->once();
         });
 
         $this->assertInstanceOf(
@@ -259,7 +259,7 @@ class SizeTest extends TestCase
             $mock->shouldReceive('width')->andReturn(100)->times(4);
             $mock->shouldReceive('height')->andReturn(100)->times(4);
             $mock->shouldReceive('scale')->with(100, 100)->andReturn($mock)->once();
-            $mock->shouldReceive('crop')->with(100, 100, 0, 0, (string) Color::transparent())->andReturn($mock)->once();
+            $mock->shouldReceive('crop')->with(100, 100, 0, 0, Color::transparent()->toString())->andReturn($mock)->once();
         });
 
         $this->assertInstanceOf(

--- a/tests/Manipulators/WatermarkTest.php
+++ b/tests/Manipulators/WatermarkTest.php
@@ -56,9 +56,9 @@ class WatermarkTest extends TestCase
     public function testRun()
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {
-            $mock->shouldReceive('place')->once();
+            $mock->shouldReceive('insert')->once();
             $mock->shouldReceive('driver')->andReturn(\Mockery::mock(DriverInterface::class, function ($mock) {
-                $mock->shouldReceive('handleInput')->with('content')->andReturn(\Mockery::mock(ImageInterface::class, function ($mock) {
+                $mock->shouldReceive('decodeImage')->with('content')->andReturn(\Mockery::mock(ImageInterface::class, function ($mock) {
                     $mock->shouldReceive('width')->andReturn(0)->once();
                     $mock->shouldReceive('scale')->once();
                 }))->once();
@@ -99,7 +99,7 @@ class WatermarkTest extends TestCase
         $this->manipulator->setWatermarksPathPrefix('watermarks');
 
         $driver = \Mockery::mock(DriverInterface::class);
-        $driver->shouldReceive('handleInput')
+        $driver->shouldReceive('decodeImage')
                ->with('content')
                ->andReturn(\Mockery::mock(ImageInterface::class))
                ->once();


### PR DESCRIPTION
This PR makes the necessary changes to migrate to the just released [Intervention Image Version 4](https://github.com/Intervention/image/releases/tag/4.0.0).

Please note that the new version requires at least PHP 8.3.

The docker test runner currently fails with an error, but this was already happening before I made any changes. Unfortunately, I can't say for sure what's causing it.

However, I think this is a good start and takes care of most of the work for the update. I recommend a thorough review.

If you have any questions, feel free to reach out to me.

PS: For your reference, here is the [upgrade guide](https://image.intervention.io/v4/getting-started/upgrade)