### PR TITLE
Fix: normalize watermark alpha to 0-1 range for Intervention Image v4

### DIFF
--- a/src/Manipulators/Watermark.php
+++ b/src/Manipulators/Watermark.php
@@ -114,7 +114,7 @@ class Watermark extends BaseManipulator
         ]);
         $watermark = $size->run($watermark);
 
-        return $image->insert($watermark, intval($markx), intval($marky), $markpos, $markalpha);
+        return $image->insert($watermark, intval($markx), intval($marky), $markpos, $markalpha / 100);
     }
 
     /**

--- a/tests/Manipulators/WatermarkTest.php
+++ b/tests/Manipulators/WatermarkTest.php
@@ -222,7 +222,7 @@ class WatermarkTest extends TestCase
         $image = \Mockery::mock(ImageInterface::class, function ($mock) use ($watermarkImage) {
             $mock->shouldReceive('insert')
                 ->withArgs(function ($wm, $x, $y, $pos, $alpha) {
-                    return $alpha >= 0 && $alpha <= 1 && $alpha === 0.65;
+                    return $alpha >= 0 && $alpha <= 1 && 0.65 === $alpha;
                 })
                 ->once()
                 ->andReturnSelf();

--- a/tests/Manipulators/WatermarkTest.php
+++ b/tests/Manipulators/WatermarkTest.php
@@ -212,6 +212,43 @@ class WatermarkTest extends TestCase
         $this->assertSame('bottom-right', $this->manipulator->setParams(['markpos' => 'invalid'])->getPosition());
     }
 
+    public function testRunNormalizesAlphaToZeroOneRange()
+    {
+        $watermarkImage = \Mockery::mock(ImageInterface::class, function ($mock) {
+            $mock->shouldReceive('width')->andReturn(0)->once();
+            $mock->shouldReceive('scale')->once();
+        });
+
+        $image = \Mockery::mock(ImageInterface::class, function ($mock) use ($watermarkImage) {
+            $mock->shouldReceive('insert')
+                ->withArgs(function ($wm, $x, $y, $pos, $alpha) {
+                    return $alpha >= 0 && $alpha <= 1 && $alpha === 0.65;
+                })
+                ->once()
+                ->andReturnSelf();
+            $mock->shouldReceive('driver')->andReturn(\Mockery::mock(DriverInterface::class, function ($mock) use ($watermarkImage) {
+                $mock->shouldReceive('decodeImage')->with('content')->andReturn($watermarkImage)->once();
+            }))->once();
+        });
+
+        $this->manipulator->setWatermarks(\Mockery::mock('League\Flysystem\FilesystemOperator', function ($watermarks) {
+            $watermarks->shouldReceive('fileExists')->with('image.jpg')->andReturn(true)->once();
+            $watermarks->shouldReceive('read')->with('image.jpg')->andReturn('content')->once();
+        }));
+
+        $this->manipulator->setParams([
+            'mark' => 'image.jpg',
+            'markw' => '100',
+            'markh' => '100',
+            'markpad' => '10',
+            'markalpha' => 65,
+        ]);
+
+        $result = $this->manipulator->run($image);
+
+        $this->assertInstanceOf(ImageInterface::class, $result);
+    }
+
     public function testGetAlpha()
     {
         $this->assertSame(100, $this->manipulator->setParams(['markalpha' => 'invalid'])->getAlpha());


### PR DESCRIPTION
## Summary

- Fixes `Watermark::getAlpha()` returning 0-100 range while Intervention Image v4's `InsertModifier` expects 0-1 float
- Normalizes the value at the call site in `run()` (`$markalpha / 100`) to maintain backwards compatibility for `getAlpha()`
- No changes to the public API — `getAlpha()` still returns `int` in 0-100 range

Closes #449

## Test plan

- [x] `testGetAlpha` assertions unchanged and passing
- [ ] Manual test: configure a Glide server with watermark filesystem and verify watermarks render without `InvalidArgumentException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)