### PR TITLE
Fix 1px background line when using focal point cropping

### DIFF
--- a/src/Manipulators/Size.php
+++ b/src/Manipulators/Size.php
@@ -346,7 +346,7 @@ class Size extends BaseManipulator
 
         $zoom = $this->getCrop()[2];
 
-        $image->scale((int) round($resize_width * $zoom), (int) round($resize_height * $zoom));
+        $image->scale((int) ceil($resize_width * $zoom), (int) ceil($resize_height * $zoom));
 
         [$offset_x, $offset_y] = $this->resolveCropOffset($image, $width, $height);
 

--- a/tests/Manipulators/SizeTest.php
+++ b/tests/Manipulators/SizeTest.php
@@ -268,6 +268,23 @@ class SizeTest extends TestCase
         );
     }
 
+    public function testRunCropResizeScalesUpToFullyCoverCropDimensions(): void
+    {
+        $image = \Mockery::mock(ImageInterface::class, function ($mock) {
+            $mock->shouldReceive('width')->andReturn(1920)->times(4);
+            $mock->shouldReceive('height')->andReturn(1278)->times(4);
+            $mock->shouldReceive('scale')->with(600, 400)->andReturn($mock)->once();
+            $mock->shouldReceive('crop')->with(600, 250, 0, 514, Color::transparent()->toString())->andReturn($mock)->once();
+        });
+
+        $this->manipulator->setParams(['fit' => 'crop-0-50']);
+
+        $this->assertInstanceOf(
+            ImageInterface::class,
+            $this->manipulator->runCropResize($image, 600, 250)
+        );
+    }
+
     public function testRunCoverResize(): void
     {
         $image = \Mockery::mock(ImageInterface::class, function ($mock) {


### PR DESCRIPTION
Focal point cropping rounds the resize dimensions down, so the scaled image can end up a pixel short of the crop and leaves a 1px background line along an edge. Rounding up instead makes the scaled image fully cover the crop.

Fixes #451